### PR TITLE
Add epilogue support and improve heading detection

### DIFF
--- a/gutenbit/chunker.py
+++ b/gutenbit/chunker.py
@@ -36,8 +36,14 @@ _ORDINAL_WORDS = (
     "eleventh|twelfth|thirteenth|fourteenth|fifteenth"
 )
 _HEADING_RE = re.compile(
-    r"^(?:CHAPTER|BOOK|PART|ACT|SCENE|SECTION|STAVE)"
+    r"^(?:CHAPTER|BOOK|PART|ACT|SCENE|SECTION|STAVE|EPILOGUE)"
     r"\.?\s+(?:[\dIVXLCDMivxlcdm]+|(?:" + _ORDINAL_WORDS + r"))[.:]?(?:\s.*)?$",
+    re.IGNORECASE,
+)
+# Matches standalone or ordinal-prefixed epilogue headings.
+# Examples: "EPILOGUE", "FIRST EPILOGUE: 1813 - 20", "SECOND EPILOGUE"
+_EPILOGUE_RE = re.compile(
+    r"^(?:(?:" + _ORDINAL_WORDS + r")\s+)?EPILOGUE[.:]?(?:\s.*)?$",
     re.IGNORECASE,
 )
 
@@ -57,6 +63,7 @@ _HEADING_RANK: dict[str, int] = {
     "book": 1,
     "part": 1,
     "act": 1,
+    "epilogue": 1,
     "chapter": 2,
     "stave": 2,
     "scene": 2,
@@ -106,8 +113,13 @@ def chunk_text(text: str) -> list[Chunk]:
         kind = "toc" if toc_start is not None and i >= toc_start else "front_matter"
         chunks.append(
             Chunk(
-                position=position, div1="", div2="", div3="", div4="",
-                content=blocks[i], kind=kind,
+                position=position,
+                div1="",
+                div2="",
+                div3="",
+                div4="",
+                content=blocks[i],
+                kind=kind,
             )
         )
         position += 1
@@ -125,8 +137,13 @@ def chunk_text(text: str) -> list[Chunk]:
         kind = "end_matter" if in_end_matter else "paragraph"
         chunks.append(
             Chunk(
-                position=position, div1=divs[0], div2=divs[1], div3=divs[2], div4=divs[3],
-                content=content, kind=kind,
+                position=position,
+                div1=divs[0],
+                div2=divs[1],
+                div3=divs[2],
+                div4=divs[3],
+                content=content,
+                kind=kind,
             )
         )
         position += 1
@@ -152,8 +169,13 @@ def chunk_text(text: str) -> list[Chunk]:
                 divs[lvl] = ""
             chunks.append(
                 Chunk(
-                    position=position, div1=divs[0], div2=divs[1], div3=divs[2], div4=divs[3],
-                    content=block, kind="heading",
+                    position=position,
+                    div1=divs[0],
+                    div2=divs[1],
+                    div3=divs[2],
+                    div4=divs[3],
+                    content=block,
+                    kind="heading",
                 )
             )
             position += 1
@@ -201,18 +223,23 @@ def _find_body_start(blocks: list[str]) -> int:
 
 def _heading_rank(block: str) -> int:
     """Return the structural rank (1 = broadest) for a heading block."""
-    keyword = block.split()[0].rstrip(".]").lower()
+    words = block.split()
+    keyword = words[0].rstrip(".],:").lower()
+    if keyword not in _HEADING_RANK and len(words) > 1:
+        # Handle ordinal-prefixed forms like "FIRST EPILOGUE", "SECOND EPILOGUE"
+        keyword = words[1].rstrip(".],:").lower()
     return _HEADING_RANK.get(keyword, 2)
 
 
 def _is_heading(block: str) -> bool:
     """Return True if *block* looks like a chapter/section heading."""
     lines = block.splitlines()
-    if len(lines) > 3:
+    if len(lines) > 5:
         return False
     # Strip a trailing ']' that may appear when a chapter heading is embedded
     # inside a split [Illustration: ...] tag (e.g. "Chapter I.]").
-    return bool(_HEADING_RE.match(lines[0].strip().rstrip("]")))
+    first = lines[0].strip().rstrip("]")
+    return bool(_HEADING_RE.match(first) or _EPILOGUE_RE.match(first))
 
 
 def _is_toc_header(block: str) -> bool:

--- a/gutenbit/download.py
+++ b/gutenbit/download.py
@@ -11,12 +11,13 @@ TEXT_URL = "https://www.gutenberg.org/ebooks/{id}.txt.utf-8"
 # These patterns match only the exact standard Gutenberg delimiters:
 #   *** START OF THE PROJECT GUTENBERG EBOOK <TITLE> ***
 #   *** END OF THE PROJECT GUTENBERG EBOOK <TITLE> ***
+# Some older texts use "THIS" instead of "THE".
 _START_MARKER_RE = re.compile(
-    r"^\*{3}\s+START OF THE PROJECT GUTENBERG EBOOK\b.*\*{3}\s*$",
+    r"^\*{3}\s+START OF (?:THE|THIS) PROJECT GUTENBERG EBOOK\b.*\*{3}\s*$",
     re.IGNORECASE,
 )
 _END_MARKER_RE = re.compile(
-    r"^\*{3}\s+END OF THE PROJECT GUTENBERG EBOOK\b.*\*{3}\s*$",
+    r"^\*{3}\s+END OF (?:THE|THIS) PROJECT GUTENBERG EBOOK\b.*\*{3}\s*$",
     re.IGNORECASE,
 )
 


### PR DESCRIPTION
## Summary
This PR enhances the text chunking and downloading modules to better handle epilogues and improve compatibility with older Project Gutenberg texts.

## Key Changes

**gutenbit/chunker.py:**
- Added `EPILOGUE` as a recognized heading keyword in `_HEADING_RE`
- Introduced new `_EPILOGUE_RE` regex pattern to match standalone and ordinal-prefixed epilogue headings (e.g., "FIRST EPILOGUE", "SECOND EPILOGUE")
- Added `"epilogue": 1` to `_HEADING_RANK` dictionary to treat epilogues as top-level structural divisions
- Enhanced `_heading_rank()` function to handle ordinal-prefixed headings by checking the second word when the first word isn't recognized
- Updated `_is_heading()` function to:
  - Increase line limit from 3 to 5 for heading blocks
  - Check both `_HEADING_RE` and `_EPILOGUE_RE` patterns
- Reformatted `Chunk` constructor calls for improved readability (multi-line formatting)

**gutenbit/download.py:**
- Updated `_START_MARKER_RE` and `_END_MARKER_RE` to accept both "THE" and "THIS" in Project Gutenberg delimiters
- Added comment explaining that older texts use "THIS" instead of "THE"

## Implementation Details
The epilogue handling uses a two-regex approach: the main `_HEADING_RE` catches simple "EPILOGUE" keywords, while the dedicated `_EPILOGUE_RE` specifically handles ordinal-prefixed forms. The `_heading_rank()` function intelligently falls back to checking the second word when the first word (typically an ordinal) isn't in the rank dictionary, enabling proper structural classification of epilogues regardless of their prefix.

https://claude.ai/code/session_01MG4pLk3Gwy58qyeY6cVeDp