### PR TITLE
Add TOC-driven HTML chunker with fallback to text chunking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,15 +12,22 @@ ETL package for Project Gutenberg: download, parse, and store texts in SQLite.
 ## Architecture
 
 - `gutenbit/catalog.py` — CSV catalog fetch and search
-- `gutenbit/download.py` — Text download and header/footer stripping
-- `gutenbit/chunker.py` — Structural text chunking
+- `gutenbit/download.py` — Text/HTML download and header/footer stripping
+- `gutenbit/chunker.py` — Structural text chunking (plain-text fallback)
+- `gutenbit/html_chunker.py` — TOC-driven HTML chunking (primary)
 - `gutenbit/db.py` — SQLite storage with FTS5 search
 
-### Chunker
+### HTML Chunker (primary)
 
-Splits book text into labelled chunks. Kinds: `front_matter` (title page, etc.),
-`toc` (table of contents), `heading` (chapter/section headings), `paragraph` (prose),
-`end_matter` (footnotes, appendices, etc.).
+Uses the table of contents `<a class="pginternal">` links in Project Gutenberg
+HTML as the structural map. Each TOC link points to a body anchor inside an
+`<h2>`–`<h3>` tag, giving section boundaries and heading text from the markup.
+Hierarchy is determined by bold (`<b>`) tags in TOC links (broad divisions like
+BOOK/PART) and keyword-based classification as fallback.
+
+### Text Chunker (fallback)
+
+Regex-based chunking of plain text. Used when HTML is unavailable.
 
 ## Verification
 
@@ -38,7 +45,24 @@ Canonical test corpus (covers diverse structural patterns):
 | Pride and Prejudice (Austen) | 1342 | Illustrated edition with `Chapter I.]` bracket artifacts |
 | Locke's Second Treatise | 7370 | `CHAPTER. I.` period-after-keyword format |
 
-Typical live check:
+Typical live check (HTML — preferred):
+
+```python
+import httpx, zipfile, io
+from gutenbit.html_chunker import chunk_html
+
+book_id = 2600  # swap as needed
+url = f"https://www.gutenberg.org/cache/epub/{book_id}/pg{book_id}-h.zip"
+resp = httpx.get(url, verify=False, timeout=60)
+z = zipfile.ZipFile(io.BytesIO(resp.content))
+html = z.read([n for n in z.namelist() if n.endswith('.html')][0]).decode()
+chunks = chunk_html(html)
+headings = [c for c in chunks if c.kind == "heading"]
+for h in headings[:20]:
+    print(f"div1={h.div1!r:25s} div2={h.div2!r:20s}  {h.content!r}")
+```
+
+Plain-text fallback:
 
 ```python
 import httpx

--- a/gutenbit/db.py
+++ b/gutenbit/db.py
@@ -9,8 +9,9 @@ from dataclasses import astuple, dataclass
 from pathlib import Path
 
 from gutenbit.catalog import BookRecord
-from gutenbit.chunker import chunk_text
-from gutenbit.download import download_text, strip_headers
+from gutenbit.chunker import Chunk, chunk_text
+from gutenbit.download import download_html, download_text, strip_headers
+from gutenbit.html_chunker import chunk_html
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +123,11 @@ class Database:
     # ------------------------------------------------------------------
 
     def ingest(self, books: list[BookRecord], *, delay: float = 1.0) -> None:
-        """Download, clean, chunk, and store books. Skips already-downloaded books."""
+        """Download, clean, chunk, and store books. Skips already-downloaded books.
+
+        Tries the HTML version first (better structural parsing via TOC),
+        falling back to plain text if HTML is unavailable.
+        """
         for book in books:
             if self._has_text(book.id):
                 logger.info("Skipping %s (already downloaded)", book.title)
@@ -130,13 +135,28 @@ class Database:
 
             logger.info("Downloading %s (id=%d)", book.title, book.id)
             try:
-                raw = download_text(book.id)
-                clean = strip_headers(raw)
-                self._store(book, clean)
+                self._ingest_one(book)
             except Exception:
                 logger.exception("Failed to download %s (id=%d)", book.title, book.id)
 
             time.sleep(delay)
+
+    def _ingest_one(self, book: BookRecord) -> None:
+        """Download and store a single book, trying HTML then text."""
+        # Try HTML first for TOC-driven structural parsing
+        try:
+            html = download_html(book.id)
+            chunks = chunk_html(html)
+            if chunks:
+                self._store_chunks(book, chunks)
+                return
+        except Exception:
+            logger.debug("HTML not available for %s, falling back to text", book.title)
+
+        # Fall back to plain text
+        raw = download_text(book.id)
+        clean = strip_headers(raw)
+        self._store(book, clean)
 
     # ------------------------------------------------------------------
     # Query helpers
@@ -268,6 +288,30 @@ class Database:
     def _has_text(self, book_id: int) -> bool:
         row = self._conn.execute("SELECT 1 FROM texts WHERE book_id = ?", (book_id,)).fetchone()
         return row is not None
+
+    def _store_chunks(self, book: BookRecord, chunks: list[Chunk]) -> None:
+        """Store pre-chunked content (from HTML chunker)."""
+        text = "\n\n".join(c.content for c in chunks)
+        with self._conn:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO books"
+                " (id, title, authors, language, subjects, locc, bookshelves, issued, type)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                astuple(book),
+            )
+            self._conn.execute(
+                "INSERT OR REPLACE INTO texts (book_id, content) VALUES (?, ?)",
+                (book.id, text),
+            )
+            self._conn.execute("DELETE FROM chunks WHERE book_id = ?", (book.id,))
+            self._conn.executemany(
+                "INSERT INTO chunks (book_id, div1, div2, div3, div4, position, content, kind)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                [
+                    (book.id, c.div1, c.div2, c.div3, c.div4, c.position, c.content, c.kind)
+                    for c in chunks
+                ],
+            )
 
     def _store(self, book: BookRecord, text: str) -> None:
         chunks = chunk_text(text)

--- a/gutenbit/download.py
+++ b/gutenbit/download.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import io
 import re
+import zipfile
 
 import httpx
 
 TEXT_URL = "https://www.gutenberg.org/ebooks/{id}.txt.utf-8"
+HTML_ZIP_URL = "https://www.gutenberg.org/cache/epub/{id}/pg{id}-h.zip"
 
 # These patterns match only the exact standard Gutenberg delimiters:
 #   *** START OF THE PROJECT GUTENBERG EBOOK <TITLE> ***
@@ -28,6 +31,22 @@ def download_text(book_id: int) -> str:
     response = httpx.get(url, follow_redirects=True, timeout=30.0)
     response.raise_for_status()
     return response.text
+
+
+def download_html(book_id: int) -> str:
+    """Download the HTML version of a book from Project Gutenberg.
+
+    Downloads the epub HTML zip, extracts the single HTML file, and returns
+    its content as a string.
+    """
+    url = HTML_ZIP_URL.format(id=book_id)
+    response = httpx.get(url, follow_redirects=True, timeout=60.0)
+    response.raise_for_status()
+    z = zipfile.ZipFile(io.BytesIO(response.content))
+    html_names = [n for n in z.namelist() if n.endswith(".html")]
+    if not html_names:
+        raise ValueError(f"No HTML file found in zip for book {book_id}")
+    return z.read(html_names[0]).decode("utf-8")
 
 
 def strip_headers(text: str) -> str:

--- a/gutenbit/html_chunker.py
+++ b/gutenbit/html_chunker.py
@@ -1,0 +1,346 @@
+"""TOC-driven HTML chunker for Project Gutenberg books.
+
+Uses the table of contents ``<a class="pginternal">`` links as the primary
+structural map, rather than regex-based content heuristics.  Each TOC link
+points to a body anchor inside an ``<h2>``–``<h6>`` tag, giving us section
+boundaries and heading text directly from the markup.
+
+Produces the same ``Chunk`` dataclass as ``chunker.py`` for compatibility.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from bs4 import BeautifulSoup, Tag
+
+# Re-use the Chunk dataclass from the text chunker for compatibility.
+from gutenbit.chunker import Chunk
+
+# ---------------------------------------------------------------------------
+# Heading hierarchy helpers
+# ---------------------------------------------------------------------------
+
+_BROAD_KEYWORDS = frozenset({"book", "part", "act", "epilogue", "volume"})
+
+# Matches BOOK/PART/CHAPTER etc. headings for level classification fallback.
+_HEADING_KEYWORD_RE = re.compile(
+    r"^(?:BOOK|PART|ACT|EPILOGUE|VOLUME|CHAPTER|STAVE|SCENE|SECTION)"
+    r"\.?\s",
+    re.IGNORECASE,
+)
+
+_END_MATTER_RE = re.compile(
+    r"^(?:FOOTNOTES?|APPENDIX|GLOSSARY|INDEX|END OF)\b",
+    re.IGNORECASE,
+)
+
+_MIN_CHUNK_LEN = 50
+
+
+@dataclass(frozen=True, slots=True)
+class _Section:
+    """A section parsed from the TOC."""
+
+    anchor_id: str
+    heading_text: str
+    level: int  # 1 = broad (BOOK/PART), 2 = chapter, 3 = sub-chapter
+    body_anchor: Tag
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def chunk_html(html: str) -> list[Chunk]:
+    """Split an HTML book into labelled chunks using the TOC as structural map.
+
+    Returns chunks in document order, compatible with ``chunker.chunk_text``.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    # 1. Strip PG boilerplate
+    for section_id in ("pg-header", "pg-footer"):
+        el = soup.find(id=section_id)
+        if el:
+            el.decompose()
+
+    # 2. Build section list from TOC links
+    sections = _parse_toc_sections(soup)
+    if not sections:
+        return []
+
+    # 3. Build chunks
+    chunks: list[Chunk] = []
+    position = 0
+    divs = ["", "", "", ""]  # [div1, div2, div3, div4]
+
+    # --- Front matter: everything before first section anchor ---
+    front_paragraphs = _paragraphs_before(soup, sections[0].body_anchor)
+    for text in front_paragraphs:
+        chunks.append(
+            Chunk(
+                position=position,
+                div1="",
+                div2="",
+                div3="",
+                div4="",
+                content=text,
+                kind="front_matter",
+            )
+        )
+        position += 1
+
+    # --- Body sections ---
+    for i, section in enumerate(sections):
+        # Update division tracking
+        rank = section.level
+        divs[rank - 1] = section.heading_text
+        for lvl in range(rank, 4):
+            divs[lvl] = ""
+
+        # Heading chunk
+        chunks.append(
+            Chunk(
+                position=position,
+                div1=divs[0],
+                div2=divs[1],
+                div3=divs[2],
+                div4=divs[3],
+                content=section.heading_text,
+                kind="heading",
+            )
+        )
+        position += 1
+
+        # Paragraphs until next section (or end of document)
+        next_anchor = sections[i + 1].body_anchor if i + 1 < len(sections) else None
+        paragraphs = _paragraphs_between(section.body_anchor, next_anchor)
+        position = _emit_paragraphs(paragraphs, divs, chunks, position)
+
+    return chunks
+
+
+def _emit_paragraphs(
+    paragraphs: list[str],
+    divs: list[str],
+    chunks: list[Chunk],
+    position: int,
+) -> int:
+    """Accumulate paragraph texts into chunks, detecting end matter.
+
+    Returns the updated *position* counter.
+    """
+    in_end_matter = False
+    buffer: list[str] = []
+
+    def flush() -> int:
+        nonlocal in_end_matter
+        nonlocal position
+        if not buffer:
+            return position
+        content = "\n\n".join(buffer)
+        kind = "end_matter" if in_end_matter else "paragraph"
+        chunks.append(
+            Chunk(
+                position=position,
+                div1=divs[0],
+                div2=divs[1],
+                div3=divs[2],
+                div4=divs[3],
+                content=content,
+                kind=kind,
+            )
+        )
+        position += 1
+        buffer.clear()
+        return position
+
+    for text in paragraphs:
+        if not in_end_matter and _END_MATTER_RE.match(text):
+            position = flush()
+            in_end_matter = True
+
+        buffer.append(text)
+        if in_end_matter or sum(len(b) for b in buffer) >= _MIN_CHUNK_LEN:
+            position = flush()
+
+    position = flush()
+    return position
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_toc_sections(soup: BeautifulSoup) -> list[_Section]:
+    """Extract section list from TOC ``pginternal`` links."""
+    toc_links = soup.select("a.pginternal")
+    sections: list[_Section] = []
+    used_headings: set[int] = set()
+
+    for link in toc_links:
+        href = link.get("href", "")
+        if not href.startswith("#"):
+            continue
+        anchor_id = href[1:]
+        body_anchor = soup.find("a", id=anchor_id)
+        if not body_anchor:
+            continue
+
+        # Find the associated heading element.  Two patterns exist:
+        #   1. Anchor inside the heading:  <h2><a id="...">TEXT</a></h2>
+        #   2. Anchor before the heading:  <p><a id="..."></a></p> ... <h2>TEXT</h2>
+        heading_el = body_anchor.find_parent(["h1", "h2", "h3", "h4", "h5", "h6"])
+        if not heading_el:
+            heading_el = _find_next_heading(body_anchor, used_headings)
+        if not heading_el:
+            continue
+        if id(heading_el) in used_headings:
+            continue
+        used_headings.add(id(heading_el))
+
+        heading_text = _extract_heading_text(heading_el)
+        if not heading_text:
+            continue
+
+        # Determine hierarchy level
+        is_bold = link.find("b") is not None
+        level = _classify_level(heading_text, is_bold)
+
+        sections.append(_Section(anchor_id, heading_text, level, body_anchor))
+
+    return sections
+
+
+def _find_next_heading(anchor: Tag, used_headings: set[int] | None = None) -> Tag | None:
+    """Find the next major heading element after *anchor*, within a few elements.
+
+    Only matches ``<h1>``–``<h3>`` tags (not ``<h4>``–``<h6>`` which are often
+    used for illustration captions).  Skips headings already claimed by another
+    anchor (tracked via *used_headings* set of element ids).
+    """
+    for el in anchor.find_all_next(limit=10):
+        if isinstance(el, Tag) and el.name in ("h1", "h2", "h3"):
+            if used_headings is not None and id(el) in used_headings:
+                continue
+            return el
+    return None
+
+
+def _extract_heading_text(heading_el: Tag) -> str:
+    """Get clean heading text from an ``<h2>`` tag.
+
+    Handles several Project Gutenberg HTML patterns:
+    - Direct text nodes in the heading (most common)
+    - Text inside ``<a>`` anchors (e.g. Christmas Carol ``<a id="...">STAVE ONE.</a>``)
+    - Illustrated editions where heading text is in ``<img alt="...">``
+    - Page-number spans (``<span class="pagenum">``) that should be ignored
+    """
+    # Remove page-number spans before extracting text
+    heading_copy = BeautifulSoup(str(heading_el), "html.parser")
+    for pagenum in heading_copy.select("span.pagenum"):
+        pagenum.decompose()
+
+    # Try direct text nodes first (handles P&P's image-caption h2 elements)
+    root = heading_copy.find(["h1", "h2", "h3", "h4", "h5", "h6"])
+    if not root:
+        root = heading_copy
+
+    direct_text = ""
+    for child in root.children:
+        if isinstance(child, str):
+            direct_text += child
+
+    cleaned = " ".join(direct_text.split()).strip()
+    if cleaned:
+        return cleaned
+
+    # Try img alt text (illustrated editions use images for heading text)
+    img = root.find("img", alt=True)
+    if img:
+        alt = " ".join(img["alt"].split()).strip()
+        if alt:
+            return alt
+
+    # Fall back to full text content (headings with text inside child elements)
+    return " ".join(root.get_text().split()).strip()
+
+
+def _classify_level(heading_text: str, is_bold_in_toc: bool) -> int:
+    """Determine structural level: 1=broad (BOOK/PART), 2=chapter, 3=sub-chapter."""
+    # Bold in TOC reliably signals broader divisions
+    if is_bold_in_toc:
+        return 1
+
+    # Fall back to keyword-based classification
+    m = _HEADING_KEYWORD_RE.match(heading_text)
+    if m:
+        keyword = heading_text.split()[0].rstrip(".,:]").lower()
+        if keyword in _BROAD_KEYWORDS:
+            return 1
+        if keyword == "section":
+            return 3
+        return 2  # CHAPTER, STAVE, SCENE
+
+    # Default to chapter level
+    return 2
+
+
+def _paragraphs_before(soup: BeautifulSoup, stop_anchor: Tag) -> list[str]:
+    """Collect paragraph text from body start up to *stop_anchor*."""
+    body = soup.find("body")
+    if not body:
+        return []
+
+    paragraphs: list[str] = []
+    for el in body.descendants:
+        if el is stop_anchor or _is_ancestor_of(el, stop_anchor):
+            break
+        if isinstance(el, Tag) and el.name == "p":
+            text = " ".join(el.get_text().split()).strip()
+            if text:
+                paragraphs.append(text)
+
+    return paragraphs
+
+
+def _paragraphs_between(start_anchor: Tag, stop_anchor: Tag | None) -> list[str]:
+    """Collect paragraph text between two body anchors.
+
+    Walks siblings/parents from *start_anchor*'s heading element forward,
+    collecting ``<p>`` text until *stop_anchor* is reached.
+    """
+    # Start from the heading element containing the anchor
+    heading_el = start_anchor.find_parent(["h1", "h2", "h3", "h4", "h5", "h6"])
+    start_el = heading_el if heading_el else start_anchor
+
+    paragraphs: list[str] = []
+    for el in start_el.find_all_next():
+        if stop_anchor and (el is stop_anchor or el is stop_anchor.parent):
+            break
+        # Stop if we hit a heading that contains the stop anchor
+        if stop_anchor and isinstance(el, Tag):
+            stop_heading = stop_anchor.find_parent(["h1", "h2", "h3", "h4", "h5", "h6"])
+            if stop_heading and el is stop_heading:
+                break
+
+        if isinstance(el, Tag) and el.name == "p":
+            text = " ".join(el.get_text().split()).strip()
+            if text:
+                paragraphs.append(text)
+
+    return paragraphs
+
+
+def _is_ancestor_of(potential_ancestor: object, target: Tag) -> bool:
+    """Check if *potential_ancestor* is an ancestor of *target*."""
+    parent = target.parent
+    while parent:
+        if parent is potential_ancestor:
+            return True
+        parent = parent.parent
+    return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Download, parse, and store Project Gutenberg texts in SQLite"
 requires-python = ">=3.11"
 dependencies = [
+    "beautifulsoup4>=4.12",
     "httpx>=0.27",
 ]
 

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -163,12 +163,12 @@ def test_no_chapter_gives_empty_string():
 def test_heading_variants():
     # Maps heading keyword → (div_field, expected_normalised_value)
     _cases = [
-        ("BOOK III",        "div1", "BOOK III"),
-        ("Part 2",          "div1", "Part 2"),
-        ("ACT IV",          "div1", "ACT IV"),
-        ("SCENE 1",         "div2", "SCENE 1"),
-        ("Section 5",       "div3", "Section 5"),
-        ("STAVE I",         "div2", "STAVE I"),
+        ("BOOK III", "div1", "BOOK III"),
+        ("Part 2", "div1", "Part 2"),
+        ("ACT IV", "div1", "ACT IV"),
+        ("SCENE 1", "div2", "SCENE 1"),
+        ("Section 5", "div3", "Section 5"),
+        ("STAVE I", "div2", "STAVE I"),
         ("CHAPTER. XVIII.", "div2", "CHAPTER. XVIII."),
     ]
     content = "Some content that is long enough to pass the minimum length filter."

--- a/tests/test_html_chunker.py
+++ b/tests/test_html_chunker.py
@@ -1,0 +1,348 @@
+"""Tests for HTML chunker: TOC-driven structural parsing."""
+
+from gutenbit.html_chunker import chunk_html
+
+# ------------------------------------------------------------------
+# Helper to build minimal PG-style HTML
+# ------------------------------------------------------------------
+
+_PG_TEMPLATE = """\
+<!DOCTYPE html>
+<html lang="en">
+<head><title>Test Book</title></head>
+<body>
+<section class="pg-boilerplate pgheader" id="pg-header">
+  <h2 id="pg-header-heading">The Project Gutenberg eBook of Test</h2>
+  <div id="pg-start-separator">*** START ***</div>
+</section>
+{body}
+<section class="pg-boilerplate pgfooter" id="pg-footer">
+  <p>End of the Project Gutenberg eBook</p>
+</section>
+</body>
+</html>
+"""
+
+
+def _make_html(body: str) -> str:
+    return _PG_TEMPLATE.format(body=body)
+
+
+# ------------------------------------------------------------------
+# Basic structure
+# ------------------------------------------------------------------
+
+
+def test_empty_html():
+    html = _make_html("")
+    assert chunk_html(html) == []
+
+
+def test_no_toc_links():
+    html = _make_html("<p>Just a paragraph with no table of contents links.</p>")
+    assert chunk_html(html) == []
+
+
+def test_single_chapter():
+    html = _make_html("""
+    <p class="toc"><a href="#ch1" class="pginternal">CHAPTER I</a></p>
+    <h2><a id="ch1"></a>CHAPTER I</h2>
+    <p>It was the best of times, it was the worst of times, in a long paragraph.</p>
+    <p>Another paragraph of sufficient length to pass the minimum chunk size filter.</p>
+    """)
+    chunks = chunk_html(html)
+    headings = [c for c in chunks if c.kind == "heading"]
+    paragraphs = [c for c in chunks if c.kind == "paragraph"]
+
+    assert len(headings) == 1
+    assert headings[0].content == "CHAPTER I"
+    assert headings[0].div2 == "CHAPTER I"
+    assert len(paragraphs) >= 1
+
+
+def test_multiple_chapters():
+    html = _make_html("""
+    <p class="toc"><a href="#ch1" class="pginternal">CHAPTER I</a></p>
+    <p class="toc"><a href="#ch2" class="pginternal">CHAPTER II</a></p>
+    <p class="toc"><a href="#ch3" class="pginternal">CHAPTER III</a></p>
+    <h2><a id="ch1"></a>CHAPTER I</h2>
+    <p>First chapter content with enough text to be a real paragraph easily.</p>
+    <h2><a id="ch2"></a>CHAPTER II</h2>
+    <p>Second chapter content with enough text to be a real paragraph easily.</p>
+    <h2><a id="ch3"></a>CHAPTER III</h2>
+    <p>Third chapter content with enough text to be a real paragraph easily.</p>
+    """)
+    chunks = chunk_html(html)
+    headings = [c for c in chunks if c.kind == "heading"]
+
+    assert len(headings) == 3
+    assert [h.content for h in headings] == ["CHAPTER I", "CHAPTER II", "CHAPTER III"]
+
+
+def test_positions_are_sequential():
+    html = _make_html("""
+    <p class="toc"><a href="#ch1" class="pginternal">CHAPTER I</a></p>
+    <h2><a id="ch1"></a>CHAPTER I</h2>
+    <p>Content that is long enough to be a standalone paragraph in the chunker module.</p>
+    <p>More content that is also long enough for a second standalone paragraph.</p>
+    """)
+    chunks = chunk_html(html)
+    assert [c.position for c in chunks] == list(range(len(chunks)))
+
+
+# ------------------------------------------------------------------
+# Hierarchy detection
+# ------------------------------------------------------------------
+
+
+def test_bold_toc_link_is_div1():
+    """Bold text in TOC links signals broader divisions (BOOK, PART)."""
+    html = _make_html("""
+    <p><a href="#b1" class="pginternal"><b>BOOK ONE: 1805</b></a></p>
+    <p><a href="#ch1" class="pginternal">CHAPTER I</a></p>
+    <h2><a id="b1"></a>BOOK ONE: 1805</h2>
+    <p>Book introduction paragraph with enough text to pass the length filter.</p>
+    <h2><a id="ch1"></a>CHAPTER I</h2>
+    <p>Chapter content paragraph with enough text to pass the minimum length filter.</p>
+    """)
+    chunks = chunk_html(html)
+    headings = [c for c in chunks if c.kind == "heading"]
+
+    assert len(headings) == 2
+    # BOOK ONE should be div1
+    assert headings[0].div1 == "BOOK ONE: 1805"
+    assert headings[0].div2 == ""
+    # CHAPTER I should inherit div1 and set div2
+    assert headings[1].div1 == "BOOK ONE: 1805"
+    assert headings[1].div2 == "CHAPTER I"
+
+
+def test_keyword_based_hierarchy_without_bold():
+    """When no bold, BOOK/PART keywords are classified as div1."""
+    html = _make_html("""
+    <p><a href="#p1" class="pginternal">PART I</a></p>
+    <p><a href="#ch1" class="pginternal">CHAPTER I</a></p>
+    <h2><a id="p1"></a>PART I</h2>
+    <p>Part introduction content that is long enough for the chunker module.</p>
+    <h2><a id="ch1"></a>CHAPTER I</h2>
+    <p>Chapter content paragraph with enough text to pass the minimum length filter.</p>
+    """)
+    chunks = chunk_html(html)
+    headings = [c for c in chunks if c.kind == "heading"]
+
+    assert headings[0].div1 == "PART I"
+    assert headings[1].div1 == "PART I"
+    assert headings[1].div2 == "CHAPTER I"
+
+
+def test_div_reset_on_new_broad_heading():
+    """A new broad heading (BOOK/PART) resets div2."""
+    html = _make_html("""
+    <p><a href="#b1" class="pginternal"><b>BOOK ONE</b></a></p>
+    <p><a href="#ch1" class="pginternal">CHAPTER I</a></p>
+    <p><a href="#b2" class="pginternal"><b>BOOK TWO</b></a></p>
+    <p><a href="#ch2" class="pginternal">CHAPTER I</a></p>
+    <h2><a id="b1"></a>BOOK ONE</h2>
+    <p>Enough text here to be a paragraph in the chunker module easily.</p>
+    <h2><a id="ch1"></a>CHAPTER I</h2>
+    <p>Chapter one content with enough text to pass the minimum length filter.</p>
+    <h2><a id="b2"></a>BOOK TWO</h2>
+    <p>Enough text here again to be a paragraph in the chunker module easily.</p>
+    <h2><a id="ch2"></a>CHAPTER I</h2>
+    <p>New chapter one content with enough text to pass the minimum length filter.</p>
+    """)
+    chunks = chunk_html(html)
+    headings = [c for c in chunks if c.kind == "heading"]
+
+    assert headings[2].div1 == "BOOK TWO"
+    assert headings[2].div2 == ""  # Reset
+    assert headings[3].div1 == "BOOK TWO"
+    assert headings[3].div2 == "CHAPTER I"
+
+
+# ------------------------------------------------------------------
+# Anchor patterns
+# ------------------------------------------------------------------
+
+
+def test_anchor_before_heading_pattern():
+    """Nicholas Nickleby pattern: anchor in <p>, heading follows as sibling."""
+    html = _make_html("""
+    <p class="toc"><a href="#link2HCH0001" class="pginternal">CHAPTER 1</a></p>
+    <p><a id="link2HCH0001"><!--  H2 anchor --></a></p>
+    <div style="height: 4em;"><br></div>
+    <h2>CHAPTER 1</h2>
+    <p>Content of chapter one, with enough text to be a standalone paragraph.</p>
+    """)
+    chunks = chunk_html(html)
+    headings = [c for c in chunks if c.kind == "heading"]
+
+    assert len(headings) == 1
+    assert headings[0].content == "CHAPTER 1"
+    assert headings[0].div2 == "CHAPTER 1"
+
+
+def test_illustration_links_ignored():
+    """Links pointing to <h4>/<h5> illustration captions are skipped."""
+    html = _make_html("""
+    <p><a href="#stave1" class="pginternal">MARLEY'S GHOST</a></p>
+    <p><a href="#illust1" class="pginternal">Marley's Ghost Illustration</a></p>
+    <h2><a id="stave1"></a>STAVE ONE.</h2>
+    <p>Marley was dead paragraph with enough text for the chunker filter.</p>
+    <p><a id="illust1"></a></p>
+    <h4><i>Marley's Ghost Illustration</i></h4>
+    <p>More text after illustration with enough text for the chunker filter.</p>
+    """)
+    chunks = chunk_html(html)
+    headings = [c for c in chunks if c.kind == "heading"]
+
+    assert len(headings) == 1
+    assert headings[0].content == "STAVE ONE."
+
+
+def test_page_number_links_ignored():
+    """Page-number links (anchors in non-heading elements) are skipped."""
+    html = _make_html("""
+    <p><a href="#ch1" class="pginternal">CHAPTER I</a></p>
+    <p><a href="#page_42" class="pginternal">42</a></p>
+    <h2><a id="ch1"></a>CHAPTER I</h2>
+    <p>Content paragraph with enough text for the chunker minimum length filter.</p>
+    <p><a id="page_42"></a>More text at page forty-two with enough content.</p>
+    """)
+    chunks = chunk_html(html)
+    headings = [c for c in chunks if c.kind == "heading"]
+
+    assert len(headings) == 1
+    assert headings[0].content == "CHAPTER I"
+
+
+# ------------------------------------------------------------------
+# PG boilerplate stripping
+# ------------------------------------------------------------------
+
+
+def test_pg_header_stripped():
+    html = _make_html("""
+    <p class="toc"><a href="#ch1" class="pginternal">CHAPTER I</a></p>
+    <h2><a id="ch1"></a>CHAPTER I</h2>
+    <p>Content that should appear, long enough for the chunker minimum filter.</p>
+    """)
+    chunks = chunk_html(html)
+    # No chunk should contain PG boilerplate text
+    all_text = " ".join(c.content for c in chunks)
+    assert "Project Gutenberg" not in all_text
+
+
+# ------------------------------------------------------------------
+# Front matter
+# ------------------------------------------------------------------
+
+
+def test_front_matter_before_first_section():
+    html = _make_html("""
+    <p>Title Page: A Great Novel by Famous Author is right here.</p>
+    <p class="toc"><a href="#ch1" class="pginternal">CHAPTER I</a></p>
+    <h2><a id="ch1"></a>CHAPTER I</h2>
+    <p>Chapter content with enough text to pass the minimum length filter here.</p>
+    """)
+    chunks = chunk_html(html)
+    front = [c for c in chunks if c.kind == "front_matter"]
+    assert len(front) >= 1
+    assert "Famous Author" in front[0].content
+
+
+# ------------------------------------------------------------------
+# Heading text extraction
+# ------------------------------------------------------------------
+
+
+def test_heading_with_pagenum_span():
+    """Page number spans inside h2 are ignored for heading text."""
+    html = _make_html("""
+    <p><a href="#ch1" class="pginternal">CHAPTER I</a></p>
+    <h2><a id="ch1"></a><span class="pagenum"><a id="page_1">{1}</a></span>
+    CHAPTER I.</h2>
+    <p>Content paragraph with enough text for the chunker minimum length filter.</p>
+    """)
+    chunks = chunk_html(html)
+    headings = [c for c in chunks if c.kind == "heading"]
+    assert len(headings) == 1
+    assert headings[0].content == "CHAPTER I."
+
+
+def test_heading_from_img_alt():
+    """Illustrated editions use <img alt="..."> for heading text."""
+    html = _make_html("""
+    <p><a href="#ch1" class="pginternal">Chapter I</a></p>
+    <h2><a id="ch1"></a><img alt="CHAPTER I." src="ch1.jpg"></h2>
+    <p>Content paragraph with enough text for the chunker minimum length filter.</p>
+    """)
+    chunks = chunk_html(html)
+    headings = [c for c in chunks if c.kind == "heading"]
+    assert len(headings) == 1
+    assert headings[0].content == "CHAPTER I."
+
+
+# ------------------------------------------------------------------
+# End matter detection
+# ------------------------------------------------------------------
+
+
+def test_end_matter_detected():
+    html = _make_html("""
+    <p class="toc"><a href="#ch1" class="pginternal">CHAPTER I</a></p>
+    <h2><a id="ch1"></a>CHAPTER I</h2>
+    <p>Chapter content with enough text to pass the minimum length filter easily.</p>
+    <p>FOOTNOTES</p>
+    <p>1. This is a footnote with enough text to pass the minimum length filter.</p>
+    """)
+    chunks = chunk_html(html)
+    end = [c for c in chunks if c.kind == "end_matter"]
+    assert len(end) >= 1
+
+
+# ------------------------------------------------------------------
+# Short paragraph accumulation
+# ------------------------------------------------------------------
+
+
+def test_short_paragraphs_accumulated():
+    html = _make_html("""
+    <p class="toc"><a href="#ch1" class="pginternal">CHAPTER I</a></p>
+    <h2><a id="ch1"></a>CHAPTER I</h2>
+    <p>"Yes?"</p>
+    <p>"No."</p>
+    <p>"Maybe."</p>
+    <p>"Perhaps."</p>
+    """)
+    chunks = chunk_html(html)
+    paragraphs = [c for c in chunks if c.kind == "paragraph"]
+    # Short lines should be accumulated into one chunk
+    assert len(paragraphs) <= 2
+    # All dialogue should be present
+    all_text = " ".join(c.content for c in paragraphs)
+    assert '"Yes?"' in all_text
+    assert '"No."' in all_text
+
+
+# ------------------------------------------------------------------
+# Chunk kind coverage
+# ------------------------------------------------------------------
+
+
+def test_chunk_kinds():
+    """All expected chunk kinds are produced."""
+    html = _make_html("""
+    <p>Title page text for front matter with enough content for the filter.</p>
+    <p class="toc"><a href="#ch1" class="pginternal">CHAPTER I</a></p>
+    <h2><a id="ch1"></a>CHAPTER I</h2>
+    <p>Content paragraph with enough text for the chunker minimum length filter.</p>
+    <p>FOOTNOTES</p>
+    <p>1. A footnote with enough text to pass the minimum length filter easily.</p>
+    """)
+    chunks = chunk_html(html)
+    kinds = {c.kind for c in chunks}
+    assert "heading" in kinds
+    assert "paragraph" in kinds
+    assert "front_matter" in kinds
+    assert "end_matter" in kinds

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -173,7 +173,7 @@ def test_search_result_fields(tmp_path):
     assert r.book_id == 1
     assert r.title == "Moby Dick"
     assert r.authors == "Melville, Herman"
-    assert r.div1 == ""           # no PART/BOOK heading in test data
+    assert r.div1 == ""  # no PART/BOOK heading in test data
     assert r.div2 == "CHAPTER 1"  # CHAPTER is rank-2
     assert r.kind == "paragraph"
     assert r.score > 0

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -38,6 +51,7 @@ name = "gutenbit"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "beautifulsoup4" },
     { name = "httpx" },
 ]
 
@@ -49,7 +63,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "httpx", specifier = ">=0.27" }]
+requires-dist = [
+    { name = "beautifulsoup4", specifier = ">=4.12" },
+    { name = "httpx", specifier = ">=0.27" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -179,6 +196,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/fa/2ef715a1cd329ef47c1a050e10dee91a9054b7ce2fcfdd6a06d139afb7ec/ruff-0.15.4-py3-none-win32.whl", hash = "sha256:65594a2d557d4ee9f02834fcdf0a28daa8b3b9f6cb2cb93846025a36db47ef22", size = 10506664, upload-time = "2026-02-26T20:03:50.56Z" },
     { url = "https://files.pythonhosted.org/packages/d0/a8/c688ef7e29983976820d18710f955751d9f4d4eb69df658af3d006e2ba3e/ruff-0.15.4-py3-none-win_amd64.whl", hash = "sha256:04196ad44f0df220c2ece5b0e959c2f37c777375ec744397d21d15b50a75264f", size = 11651048, upload-time = "2026-02-26T20:04:17.191Z" },
     { url = "https://files.pythonhosted.org/packages/3e/0a/9e1be9035b37448ce2e68c978f0591da94389ade5a5abafa4cf99985d1b2/ruff-0.15.4-py3-none-win_arm64.whl", hash = "sha256:60d5177e8cfc70e51b9c5fad936c634872a74209f934c1e79107d11787ad5453", size = 10966776, upload-time = "2026-02-26T20:03:56.908Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a new HTML-based chunker that uses Project Gutenberg's table of contents (`<a class="pginternal">` links) as the primary structural map for parsing books. This provides more accurate section boundaries and hierarchy detection than regex-based text parsing. The system automatically falls back to plain-text chunking when HTML is unavailable.

## Key Changes

- **New `html_chunker.py` module**: TOC-driven structural parser that:
  - Extracts section boundaries from TOC links pointing to body anchors in heading elements
  - Classifies hierarchy levels (div1/div2/div3/div4) using bold tags in TOC links and keyword-based fallback
  - Handles multiple Project Gutenberg HTML patterns (anchors inside/before headings, illustrated editions with `<img alt>`, page-number spans)
  - Detects front matter (before first section) and end matter (footnotes, appendices)
  - Accumulates short paragraphs into chunks respecting minimum length thresholds

- **Updated `download.py`**: Added `download_html()` function to fetch and extract HTML from Project Gutenberg's epub zip archives

- **Updated `db.py`**: Modified ingestion pipeline to:
  - Try HTML chunking first via `chunk_html()`
  - Fall back to text-based chunking if HTML is unavailable
  - Store pre-chunked content with hierarchy metadata via new `_store_chunks()` method

- **Comprehensive test suite** (`test_html_chunker.py`): 348 lines covering:
  - Basic structure and multiple chapters
  - Hierarchy detection (bold TOC links, keyword-based classification, div reset)
  - Anchor patterns (before/inside headings, illustration links, page numbers)
  - PG boilerplate stripping
  - Front/end matter detection
  - Heading text extraction (page spans, image alt text)
  - Short paragraph accumulation

- **Documentation**: Updated `CLAUDE.md` with architecture overview and live verification examples for both HTML and text chunking

## Implementation Details

- Reuses existing `Chunk` dataclass for compatibility with text chunker
- Hierarchy tracking via `divs` list that resets lower levels when a broad heading (BOOK/PART) is encountered
- Robust heading text extraction handling Project Gutenberg's varied HTML patterns (direct text, anchored text, image captions, page-number spans)
- Graceful degradation: missing HTML falls back to proven text-based approach
- Added `beautifulsoup4` dependency for HTML parsing

https://claude.ai/code/session_01Ce3pFX1tbzoeydDvqJVQL1