### PR TITLE
Rename CLI ingest command to add

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ with Database("gutenbit.db") as db:
 
 ```bash
 gutenbit catalog --author "Austen, Jane"
-gutenbit ingest 1342
+gutenbit add 1342
 gutenbit search "pride"
 gutenbit view 1342 --section 1 -n 5
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 # CLI
 
-The `gutenbit` command-line tool provides seven subcommands that follow a natural workflow: find books, download them, explore their structure, read text, and search.
+The `gutenbit` command-line tool provides seven subcommands that follow a natural workflow: find books, add them, explore their structure, read text, and search.
 
 All commands store data in a local SQLite file. Use `--db PATH` to specify a non-default location (default: `gutenbit.db`). All commands support `--json` for machine-readable output.
 
@@ -25,14 +25,14 @@ gutenbit catalog --subject "Philosophy" -n 50
 
 Filters combine with AND logic. All matching is case-insensitive. The catalog is fetched from Project Gutenberg on each call and filtered to English text records.
 
-## ingest
+## add
 
 Download books from Project Gutenberg and store them in the database.
 
 ```bash
-gutenbit ingest 1342
-gutenbit ingest 46 730 967
-gutenbit ingest 2600 --delay 2.0
+gutenbit add 1342
+gutenbit add 46 730 967
+gutenbit add 2600 --delay 2.0
 ```
 
 | Flag | Description |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -65,7 +65,7 @@ Gutenbit enforces a fixed corpus policy during catalog fetching:
 - **Media type:** Text only.
 - **Deduplication:** When multiple Gutenberg IDs correspond to the same work (same title and author), the lowest ID is kept as the canonical edition. All other IDs remap to it.
 
-The `canonical_id` method on `Catalog` resolves any Gutenberg ID to its canonical form. During `ingest`, requested IDs are remapped automatically.
+The `canonical_id` method on `Catalog` resolves any Gutenberg ID to its canonical form. During `gutenbit add`, requested IDs are remapped automatically.
 
 ## Search
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,10 +30,10 @@ gutenbit catalog --author "Austen, Jane"
 
 ### Download and store
 
-Pass one or more Project Gutenberg IDs to `ingest`:
+Pass one or more Project Gutenberg IDs to `add`:
 
 ```bash
-gutenbit ingest 1342
+gutenbit add 1342
 ```
 
 The book's HTML is downloaded, parsed into paragraph-level chunks with structural metadata, and stored in a local SQLite database (`gutenbit.db` by default).

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ with Database("gutenbit.db") as db:
 
 ```bash
 gutenbit catalog --title "Pride and Prejudice"
-gutenbit ingest 1342
+gutenbit add 1342
 gutenbit search "truth universally acknowledged"
 gutenbit view 1342 --section 1 -n 5
 ```

--- a/gutenbit/cli.py
+++ b/gutenbit/cli.py
@@ -158,7 +158,7 @@ def _command_error(
 def _no_chunks_message(db: Database, book_id: int) -> str:
     """Return a descriptive error for a book with no chunks."""
     if db.book(book_id) is None:
-        return f"Book {book_id} is not in the database. Use 'gutenbit ingest {book_id}' to add it."
+        return f"Book {book_id} is not in the database. Use 'gutenbit add {book_id}' to add it."
     return f"No chunks found for book {book_id}."
 
 
@@ -488,7 +488,7 @@ def _build_parser() -> argparse.ArgumentParser:
         epilog="""\
 typical workflow:
   1. gutenbit catalog --author Dickens         # find book IDs
-  2. gutenbit ingest 46 730                    # download & store
+  2. gutenbit add 46 730                       # download & store
   3. gutenbit books                            # list stored books
   4. gutenbit toc 46                           # inspect structure / sections
   5. gutenbit view 46 --section 3 -n 20        # read part of a book
@@ -526,9 +526,9 @@ all filters use case-insensitive substring matching (AND logic).""",
     cat.add_argument("--json", action="store_true", help="output as JSON")
     _add_global_args(cat)
 
-    # --- ingest ---
-    ing = sub.add_parser(
-        "ingest",
+    # --- add ---
+    add = sub.add_parser(
+        "add",
         formatter_class=fmt,
         help="download and store books by PG id",
         description=(
@@ -538,19 +538,19 @@ all filters use case-insensitive substring matching (AND logic).""",
         ),
         epilog="""\
 examples:
-  gutenbit ingest 2600                  # War and Peace
-  gutenbit ingest 46 730 967            # multiple books
-  gutenbit ingest 2600 --delay 2.0      # polite crawling""",
+  gutenbit add 2600                     # War and Peace
+  gutenbit add 46 730 967               # multiple books
+  gutenbit add 2600 --delay 2.0         # polite crawling""",
     )
-    ing.add_argument("book_ids", nargs="+", type=int, help="Project Gutenberg book IDs")
-    ing.add_argument(
+    add.add_argument("book_ids", nargs="+", type=int, help="Project Gutenberg book IDs")
+    add.add_argument(
         "--delay",
         type=float,
         default=1.0,
         help="seconds between downloads (default: 1.0)",
     )
-    ing.add_argument("--json", action="store_true", help="output as JSON")
-    _add_global_args(ing)
+    add.add_argument("--json", action="store_true", help="output as JSON")
+    _add_global_args(add)
 
     # --- delete ---
     de = sub.add_parser(
@@ -558,7 +558,7 @@ examples:
         formatter_class=fmt,
         help="delete stored books by PG id",
         description=(
-            "Delete previously ingested books from the SQLite database, including "
+            "Delete previously added books from the SQLite database, including "
             "their reconstructed text and all chunks."
         ),
         epilog="""\
@@ -578,7 +578,7 @@ if a book ID is not present, a warning is printed and exit code is 1.""",
         "books",
         formatter_class=fmt,
         help="list books stored in the database",
-        description="List all books that have been ingested into the database.",
+        description="List all books that have been added to the database.",
         epilog="""\
 examples:
   gutenbit books
@@ -843,15 +843,15 @@ def _cmd_catalog(args: argparse.Namespace) -> int:
     return 0
 
 
-def _cmd_ingest(args: argparse.Namespace) -> int:
+def _cmd_add(args: argparse.Namespace) -> int:
     as_json = getattr(args, "json", False)
     if args.delay < 0:
-        return _command_error("ingest", "--delay must be >= 0.", as_json=as_json)
+        return _command_error("add", "--delay must be >= 0.", as_json=as_json)
 
     invalid_ids = [bid for bid in args.book_ids if bid <= 0]
     if invalid_ids:
         return _command_error(
-            "ingest",
+            "add",
             f"Book IDs must be positive integers, got: {', '.join(map(str, invalid_ids))}",
             as_json=as_json,
             data={"invalid_ids": invalid_ids},
@@ -908,7 +908,7 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
             "results": request_results,
         }
         return _command_error(
-            "ingest",
+            "add",
             "No valid book IDs provided.",
             as_json=as_json,
             data=data,
@@ -927,13 +927,13 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
                     print(f"  skipping {book.id}: {title} (already downloaded)")
                 continue
             was_present = db.has_text(book.id)
-            target_status = "reprocessed" if was_present else "ingested"
+            target_status = "reprocessed" if was_present else "added"
             if was_present:
                 if not as_json:
                     print(f"  reprocessing {book.id}: {title} (chunker updated)…")
             else:
                 if not as_json:
-                    print(f"  ingesting {book.id}: {title}…")
+                    print(f"  adding {book.id}: {title}…")
             if as_json:
                 previous_disable = logging.root.manager.disable
                 logging.disable(logging.CRITICAL)
@@ -945,7 +945,7 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
                     canonical_statuses[book.id] = target_status
                 else:
                     canonical_statuses[book.id] = "failed"
-                    errors.append(f"Failed to ingest {book.id}: {title}")
+                    errors.append(f"Failed to add {book.id}: {title}")
             else:
                 canonical_statuses[book.id] = target_status
                 db.ingest([book], delay=args.delay)
@@ -957,11 +957,11 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
             result = dict(row)
             canonical_id = result.get("canonical_id")
             if isinstance(canonical_id, int):
-                ingest_status = canonical_statuses.get(canonical_id)
-                if ingest_status:
-                    result["ingest_status"] = ingest_status
+                add_status = canonical_statuses.get(canonical_id)
+                if add_status:
+                    result["add_status"] = add_status
                     if result["status"] == "selected":
-                        result["status"] = ingest_status
+                        result["status"] = add_status
                     status_totals[result["status"]] = status_totals.get(result["status"], 0) + 1
                 else:
                     status_totals[result["status"]] = status_totals.get(result["status"], 0) + 1
@@ -986,7 +986,7 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
         )
         data["failed_canonical_ids"] = failed_canonical_ids
         ok = len(failed_canonical_ids) == 0
-        _print_json_envelope("ingest", ok=ok, data=data, warnings=warnings, errors=errors)
+        _print_json_envelope("add", ok=ok, data=data, warnings=warnings, errors=errors)
         return 0 if ok else 1
 
     print(f"Done. Database: {Path(args.db).resolve()}")
@@ -1005,7 +1005,7 @@ def _cmd_books(args: argparse.Namespace) -> int:
                 data={"count": 0, "items": []},
             )
         else:
-            print("No books stored yet. Use 'gutenbit ingest <id> ...' to add some.")
+            print("No books stored yet. Use 'gutenbit add <id> ...' to add some.")
         return 0
     if as_json:
         _print_json_envelope(
@@ -1938,7 +1938,7 @@ def _cmd_view(args: argparse.Namespace) -> int:
 
 _COMMANDS = {
     "catalog": _cmd_catalog,
-    "ingest": _cmd_ingest,
+    "add": _cmd_add,
     "delete": _cmd_delete,
     "books": _cmd_books,
     "search": _cmd_search,

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1215,7 +1215,7 @@ def test_ingest_reports_skip_before_downloading(tmp_path, monkeypatch):
 
     monkeypatch.setattr(Database, "ingest", _ingest_should_not_run)
 
-    code, out, _err = _run_cli(tmp_path / "skip.db", "ingest", "888", "--delay", "0")
+    code, out, _err = _run_cli(tmp_path / "skip.db", "add", "888", "--delay", "0")
     assert code == 0
     assert "skipping 888: Already There (already downloaded)" in out
 
@@ -1243,7 +1243,7 @@ def test_ingest_reprocesses_stale_chunker_version(tmp_path, monkeypatch):
 
     monkeypatch.setattr(Database, "ingest", _capture_ingest)
 
-    code, out, _err = _run_cli(tmp_path / "stale.db", "ingest", "889", "--delay", "0")
+    code, out, _err = _run_cli(tmp_path / "stale.db", "add", "889", "--delay", "0")
     assert code == 0
     assert "reprocessing 889: Needs Refresh (chunker updated)" in out
     assert ingested_ids == [889]
@@ -1273,7 +1273,7 @@ def test_ingest_remaps_to_canonical_catalog_id(tmp_path, monkeypatch):
 
     monkeypatch.setattr(Database, "ingest", _capture_ingest)
 
-    code, out, _err = _run_cli(tmp_path / "canonical.db", "ingest", "101", "--delay", "0")
+    code, out, _err = _run_cli(tmp_path / "canonical.db", "add", "101", "--delay", "0")
     assert code == 0
     assert "remapped 101 -> 100" in out
     assert ingested_ids == [100]
@@ -1346,8 +1346,8 @@ def test_view_negative_n_rejected(tmp_path):
     assert "-n must be >= 0." in out
 
 
-def test_ingest_rejects_non_positive_ids(tmp_path):
-    code, out, _err = _run_cli(tmp_path / "any.db", "ingest", "0", "-1")
+def test_add_rejects_non_positive_ids(tmp_path):
+    code, out, _err = _run_cli(tmp_path / "any.db", "add", "0", "-1")
     assert code == 1
     assert "must be positive" in out
     assert "0" in out
@@ -1466,7 +1466,7 @@ def test_catalog_json_output(tmp_path, monkeypatch):
     assert payload["data"]["items"][0]["id"] == 777
 
 
-def test_ingest_json_output(tmp_path, monkeypatch):
+def test_add_json_output(tmp_path, monkeypatch):
     canonical = BookRecord(
         id=100,
         title="Canonical Work",
@@ -1498,7 +1498,7 @@ def test_ingest_json_output(tmp_path, monkeypatch):
 
     code, out, _err = _run_cli(
         tmp_path / "canonical.db",
-        "ingest",
+        "add",
         "101",
         "--delay",
         "0",
@@ -1507,16 +1507,17 @@ def test_ingest_json_output(tmp_path, monkeypatch):
     assert code == 0
     payload = json.loads(out)
     assert payload["ok"] is True
-    assert payload["command"] == "ingest"
+    assert payload["command"] == "add"
     assert payload["data"]["counts"]["requested"] == 1
     assert payload["data"]["counts"]["canonical"] == 1
     assert payload["data"]["results"][0]["requested_id"] == 101
     assert payload["data"]["results"][0]["canonical_id"] == 100
-    assert payload["data"]["results"][0]["status"] == "ingested"
+    assert payload["data"]["results"][0]["status"] == "added"
+    assert payload["data"]["results"][0]["add_status"] == "added"
     assert ingested_ids == [100]
 
 
-def test_ingest_json_failure_reports_failed_and_stays_parseable(tmp_path, monkeypatch):
+def test_add_json_failure_reports_failed_and_stays_parseable(tmp_path, monkeypatch):
     record = BookRecord(
         id=555,
         title="Broken Download",
@@ -1537,7 +1538,7 @@ def test_ingest_json_failure_reports_failed_and_stays_parseable(tmp_path, monkey
 
     code, out, _err = _run_cli(
         tmp_path / "broken.db",
-        "ingest",
+        "add",
         "555",
         "--delay",
         "0",
@@ -1546,10 +1547,10 @@ def test_ingest_json_failure_reports_failed_and_stays_parseable(tmp_path, monkey
     assert code == 1
     payload = json.loads(out)
     assert payload["ok"] is False
-    assert payload["command"] == "ingest"
+    assert payload["command"] == "add"
     assert payload["data"]["failed_canonical_ids"] == [555]
     assert payload["data"]["results"][0]["status"] == "failed"
-    assert "Failed to ingest 555: Broken Download" in payload["errors"]
+    assert "Failed to add 555: Broken Download" in payload["errors"]
 
 
 def test_delete_json_output(tmp_path):


### PR DESCRIPTION
## Summary
- rename the CLI subcommand from \ to \
- update CLI help, docs, and examples to use the new command name
- adjust CLI tests and user-facing output to match the renamed command

## Testing
- uv run pytest tests/test_search.py -k 'add or ingest_reports_skip_before_downloading or ingest_reprocesses_stale_chunker_version or ingest_remaps_to_canonical_catalog_id'
- uv run python -m gutenbit --help
- uv run python -m gutenbit add --help