### PR TITLE
Add radius windows to search and view CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ gutenbit catalog --author "Austen, Jane"
 gutenbit add 1342
 gutenbit search "pride"
 gutenbit view 1342 --section 1 -n 5
+gutenbit search "truth universally acknowledged" -n 3 -r 1
 ```
 
 All commands support `--json` for machine-readable output.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -84,6 +84,7 @@ gutenbit search "ghost OR spirit" --raw                   # FTS5 boolean query
 gutenbit search "Levin" --book-id 1399 --mode first
 gutenbit search "battle" --section "BOOK ONE" --book-id 2600
 gutenbit search "freedom" --kind text -n 5
+gutenbit search "ghost" -n 5 -r 2                        # include neighboring chunks
 gutenbit search "ghost" --full -n 3
 gutenbit search "battle" --count
 ```
@@ -100,6 +101,7 @@ gutenbit search "battle" --count
 | `--section SELECTOR` | Restrict to a section by path prefix or number from `toc` (number requires `--book-id`) |
 | `--kind KIND` | Filter by chunk kind: `heading` or `text` |
 | `-n`, `--limit N` | Maximum results (default: 20 for ranked, 1 for first/last) |
+| `-r`, `--radius N` | Neighboring chunks to include on each side of each hit |
 | `--count` | Just print the number of matching chunks |
 | `--full` | Print full chunk text instead of previews |
 | `--preview-chars N` | Preview length per result (default: 140) |
@@ -118,6 +120,12 @@ By default, punctuation in the query is auto-escaped so apostrophes, hyphens, an
 - **ranked**: Results ordered by BM25 relevance score, then book ID, then position.
 - **first**: Earliest matches. Ordered by book ID ascending, then position ascending.
 - **last**: Latest matches. Ordered by book ID descending, then position descending.
+
+### Result shaping
+
+- Use `-n` to control how many hits are returned.
+- Use `-r` to include context chunks before and after each hit.
+- `--count` cannot be combined with `-r`.
 
 ### FTS5 query syntax
 
@@ -161,8 +169,10 @@ gutenbit view 1342 -n 0                         # full text
 gutenbit view 1342 --section 3                  # section by number
 gutenbit view 1342 --section "Chapter 1" -n 10  # section by path
 gutenbit view 1342 --position 50 -n 5           # from exact position
+gutenbit view 1342 --position 50 -r 2           # centered window around position
+gutenbit view 1342 --section 3 -r 2             # centered window around section start
 gutenbit view 1342 --section 3 --meta           # with metadata headers
-gutenbit view 1342 --preview --chars 120        # concise previews
+gutenbit view 1342 --position 50 --preview --chars 120
 ```
 
 | Flag | Description |
@@ -171,12 +181,13 @@ gutenbit view 1342 --preview --chars 120        # concise previews
 | `--section SELECTOR` | Section number (from `toc`) or path prefix (e.g. `"BOOK I/CHAPTER I"`) |
 | `--position N` | Exact chunk position |
 | `-n N` | Chunks to return (default: 3 for opening, 1 for section/position; 0 = all) |
+| `-r`, `--radius N` | Neighboring chunks to include on each side of the selected center chunk |
 | `--preview` | Show truncated previews instead of full text |
 | `--chars N` | Preview length when using `--preview` (default: 140) |
 | `--meta` | Include chunk metadata headers in text output |
 | `--json` | Output as JSON |
 
-Use `--section` or `--position`, not both. Run `toc` first to see available section numbers.
+Use `--section` or `--position`, not both. `--preview` requires `--section` or `--position`. `-n` and `-r` are mutually exclusive in `view`: `-n` is a forward slice, `-r` is a centered window. Run `toc` first to see available section numbers.
 
 ## JSON output
 
@@ -193,6 +204,15 @@ Every command accepts `--json` and returns a unified envelope:
 ```
 
 When `ok` is `false`, the `errors` list contains error messages. The `data` field holds command-specific results. The `warnings` list captures non-fatal issues (e.g. a requested ID not found during bulk delete).
+
+For `view`, chunk-returning modes use an ordered `chunks` array plus mode metadata such as `n` or `radius`. Validation errors preserve that same request-shape metadata in `data` so clients can distinguish forward-slice requests from radius-window requests.
+
+For `search`, `data["items"]` remains the hit list. When `-r` is used, `data["radius"]` records the requested radius and each item gains:
+
+- `chunks`: the ordered contextual window for that hit
+- `center_index`: the matched chunk's index within `chunks`
+
+Each contextual chunk in these arrays includes a `role` field with one of `before`, `center`, or `after`.
 
 ## Global flags
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -75,4 +75,4 @@ Search uses SQLite FTS5 with BM25 ranking. The index is configured with Porter s
 - Unicode normalization handles accented characters and non-ASCII text.
 - Ranking considers term frequency, document length, and inverse document frequency across the corpus.
 
-Search results include the full text of each matching chunk along with its structural metadata, so you can identify where in a book a match occurs without a separate lookup.
+Search results include the full text of each matching chunk along with its structural metadata, so you can identify where in a book a match occurs without a separate lookup. The CLI can also attach neighboring chunks with `-r/--radius` when you want local reading context around each hit.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -68,7 +68,14 @@ Read from an exact chunk position:
 gutenbit view 1342 --position 50 -n 5
 ```
 
-The `-n` flag controls how many chunks to return. Use `-n 0` for all chunks in scope.
+Read a centered window around a position or section start:
+
+```bash
+gutenbit view 1342 --position 50 -r 2
+gutenbit view 1342 --section 1 -r 2
+```
+
+Use `-n` for forward slices and `-r` for symmetric windows. `-n 0` returns all chunks in scope.
 
 ### Search
 
@@ -88,6 +95,12 @@ Search for an exact phrase:
 
 ```bash
 gutenbit search "truth universally acknowledged" --phrase
+```
+
+Search with nearby chunk context:
+
+```bash
+gutenbit search "truth universally acknowledged" --book-id 1342 -n 3 -r 1
 ```
 
 All commands accept `--json` for machine-readable output.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ gutenbit catalog --title "Pride and Prejudice"
 gutenbit add 1342
 gutenbit search "truth universally acknowledged"
 gutenbit view 1342 --section 1 -n 5
+gutenbit search "truth universally acknowledged" -n 3 -r 1
 ```
 
 ## Next steps

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -198,6 +198,8 @@ window = db.chunk_window(1342, position=50, around=3)
 # Returns chunks at positions 47, 48, 49, 50, 51, 52, 53
 ```
 
+The CLI `view -r/--radius` and `search -r/--radius` options use this same centered-window concept.
+
 **By section path:**
 
 ```python

--- a/gutenbit/cli.py
+++ b/gutenbit/cli.py
@@ -313,6 +313,7 @@ def _chunk_payload(
     preview_chars: int,
     rank: int | None = None,
     score: float | None = None,
+    role: str | None = None,
 ) -> dict[str, Any]:
     content = row.content if full else _preview(row.content, preview_chars)
     payload = {
@@ -331,6 +332,8 @@ def _chunk_payload(
         payload["rank"] = rank
     if score is not None:
         payload["score"] = round(score, 4)
+    if role is not None:
+        payload["role"] = role
     return payload
 
 
@@ -340,9 +343,11 @@ def _search_result_payload(
     full: bool,
     preview_chars: int,
     rank: int,
+    chunks: list[dict[str, Any]] | None = None,
+    center_index: int | None = None,
 ) -> dict[str, Any]:
     content = result.content if full else _preview(result.content, preview_chars)
-    return {
+    payload = {
         "rank": rank,
         "book_id": result.book_id,
         "position": result.position,
@@ -359,6 +364,86 @@ def _search_result_payload(
         "content": content,
         "is_preview": not full,
     }
+    if chunks is not None:
+        payload["chunks"] = chunks
+    if center_index is not None:
+        payload["center_index"] = center_index
+    return payload
+
+
+def _chunk_window_payload(
+    rows: list[ChunkRecord],
+    *,
+    center_position: int,
+    full: bool,
+    preview_chars: int,
+) -> tuple[list[dict[str, Any]], int]:
+    chunks: list[dict[str, Any]] = []
+    center_index = -1
+    for idx, row in enumerate(rows):
+        if row.position < center_position:
+            role = "before"
+        elif row.position > center_position:
+            role = "after"
+        else:
+            role = "center"
+            center_index = idx
+        chunks.append(
+            _chunk_payload(
+                row,
+                full=full,
+                preview_chars=preview_chars,
+                role=role,
+            )
+        )
+    return chunks, center_index
+
+
+def _print_chunk_window(
+    rows: list[ChunkRecord],
+    *,
+    center_position: int,
+    full: bool,
+    preview_chars: int,
+    title: str = "",
+    show_meta: bool = False,
+) -> None:
+    chunks, center_index = _chunk_window_payload(
+        rows,
+        center_position=center_position,
+        full=full,
+        preview_chars=preview_chars,
+    )
+    _print_chunk_payload_window(
+        chunks,
+        center_index=center_index,
+        title=title,
+        show_meta=show_meta,
+    )
+
+
+def _print_chunk_payload_window(
+    chunks: list[dict[str, Any]],
+    *,
+    center_index: int,
+    title: str = "",
+    show_meta: bool = False,
+) -> None:
+    if title:
+        print(title)
+    for idx, chunk in enumerate(chunks, start=1):
+        role = str(chunk["role"])
+        if show_meta:
+            print(
+                f"\n{idx:>2}. role={role}  position={chunk['position']}  "
+                f"kind={chunk['kind']}  chars={chunk['char_count']}"
+            )
+            print(f"    section={chunk['section']}")
+            print(f"    {chunk['content']}")
+            continue
+        marker = "center" if idx - 1 == center_index else role
+        print(f"\n[{marker}] {chunk['content']}")
+    print(f"\n{len(chunks)} chunk(s)")
 
 
 def _print_key_value_table(
@@ -614,6 +699,7 @@ examples:
   gutenbit search "door" --mode first                       # reading order (earliest)
   gutenbit search "door" --mode last                        # reverse reading order
   gutenbit search "freedom" --kind text -n 5                # filter by chunk kind
+  gutenbit search "ghost" -n 5 -r 2                         # include neighboring chunks
   gutenbit search "ghost" --full -n 3                       # full chunk text
   gutenbit search "battle" --count                          # just show match count
   gutenbit search "battle" --json                           # JSON output
@@ -680,6 +766,13 @@ tip: use 'gutenbit toc <id>' first to see a book's structure, then
         help="max results (default: ranked=20, first/last=1; 0=default)",
     )
     se.add_argument(
+        "-r",
+        "--radius",
+        type=int,
+        default=None,
+        help="neighboring chunks on each side of each hit (default: none)",
+    )
+    se.add_argument(
         "--count",
         action="store_true",
         help="just print the number of matching chunks",
@@ -725,8 +818,8 @@ section numbers in this output can be passed to:
         description=(
             "Read from the first structural section by default, or focus from an exact position "
             "or section selector. Section selectors accept path text or a section "
-            "number from `gutenbit toc <book_id>`. Use -n consistently to control "
-            "how much text to return."
+            "number from `gutenbit toc <book_id>`. Use -n for forward slices "
+            "or -r/--radius for centered windows."
         ),
         epilog="""\
 examples:
@@ -735,8 +828,10 @@ examples:
   gutenbit view 2600 -n 0                            # full reconstructed text
   gutenbit view 2600 --section 3                     # first chunk in section 3
   gutenbit view 2600 --section 3 -n 20               # first 20 chunks in section 3
+  gutenbit view 2600 --section 3 -r 2                # centered window around section start
   gutenbit view 2600 --position 12345                # chunk at position 12345
   gutenbit view 2600 --position 12345 -n 20          # continue reading from position
+  gutenbit view 2600 --position 12345 -r 2           # centered window around position
   gutenbit view 2600 --position 12345 --preview --chars 120
   gutenbit view 2600 --section "BOOK I/CHAPTER I" -n 10 --json
   gutenbit view 2600 --section 3 -n 10 --meta        # include metadata headers
@@ -753,7 +848,7 @@ section hierarchy:  level1 > level2 > level3 > level4  (compacted from shallowes
         action="store_true",
         help="output as JSON",
     )
-    vw.add_argument("--position", type=int, help="retrieve chunks starting at this position")
+    vw.add_argument("--position", type=int, help="select the chunk at this exact position")
     vw.add_argument(
         "--section",
         help=(
@@ -779,6 +874,13 @@ section hierarchy:  level1 > level2 > level3 > level4  (compacted from shallowes
             "chunks to return (default: opening=3, section/position=1); "
             "0 means all in selected scope"
         ),
+    )
+    vw.add_argument(
+        "-r",
+        "--radius",
+        type=int,
+        default=None,
+        help="neighboring chunks on each side of the selected center chunk",
     )
     vw.add_argument(
         "--chars",
@@ -1067,8 +1169,16 @@ def _cmd_search(args: argparse.Namespace) -> int:
     as_json = getattr(args, "json", False)
     if args.limit < 0:
         return _command_error("search", "--limit must be >= 0.", as_json=as_json)
+    if args.radius is not None and args.radius < 0:
+        return _command_error("search", "--radius must be >= 0.", as_json=as_json)
     if args.preview_chars <= 0:
         return _command_error("search", "--preview-chars must be > 0.", as_json=as_json)
+    if args.count and args.radius is not None:
+        return _command_error(
+            "search",
+            "--radius cannot be used with --count.",
+            as_json=as_json,
+        )
 
     query_text = args.query.strip()
     if not query_text:
@@ -1088,6 +1198,7 @@ def _cmd_search(args: argparse.Namespace) -> int:
 
     kind = args.kind
     preview_chars = args.preview_chars
+    radius = args.radius
 
     # Resolve --section: accept a section number (from 'toc') or path prefix.
     div_path: str | None = None
@@ -1172,9 +1283,22 @@ def _cmd_search(args: argparse.Namespace) -> int:
                     },
                     "mode": args.mode,
                     "limit": limit,
+                    **({"radius": radius} if radius is not None else {}),
                 },
                 warnings=warnings,
             )
+
+        result_windows: list[tuple[list[dict[str, Any]], int]] = []
+        if radius is not None:
+            for result in results:
+                rows = db.chunk_window(result.book_id, result.position, around=radius)
+                chunks, center_index = _chunk_window_payload(
+                    rows,
+                    center_position=result.position,
+                    full=args.full,
+                    preview_chars=preview_chars,
+                )
+                result_windows.append((chunks, center_index))
 
     # --count: just print the total.
     if args.count:
@@ -1204,37 +1328,42 @@ def _cmd_search(args: argparse.Namespace) -> int:
         return 0
 
     if as_json:
+        data = {
+            "query": {
+                "raw": args.query,
+                "fts": search_query,
+                "mode": query_mode,
+            },
+            "filters": {
+                "author": args.author,
+                "title": args.title,
+                "book_id": args.book_id,
+                "section": section_arg,
+                "kind": kind,
+            },
+            "mode": args.mode,
+            "limit": limit,
+            "full": bool(args.full),
+            "preview_chars": preview_chars,
+            "count": len(results),
+            "items": [
+                _search_result_payload(
+                    r,
+                    full=args.full,
+                    preview_chars=preview_chars,
+                    rank=idx,
+                    chunks=result_windows[idx - 1][0] if radius is not None else None,
+                    center_index=result_windows[idx - 1][1] if radius is not None else None,
+                )
+                for idx, r in enumerate(results, start=1)
+            ],
+        }
+        if radius is not None:
+            data["radius"] = radius
         _print_json_envelope(
             "search",
             ok=True,
-            data={
-                "query": {
-                    "raw": args.query,
-                    "fts": search_query,
-                    "mode": query_mode,
-                },
-                "filters": {
-                    "author": args.author,
-                    "title": args.title,
-                    "book_id": args.book_id,
-                    "section": section_arg,
-                    "kind": kind,
-                },
-                "mode": args.mode,
-                "limit": limit,
-                "full": bool(args.full),
-                "preview_chars": preview_chars,
-                "count": len(results),
-                "items": [
-                    _search_result_payload(
-                        r,
-                        full=args.full,
-                        preview_chars=preview_chars,
-                        rank=idx,
-                    )
-                    for idx, r in enumerate(results, start=1)
-                ],
-            },
+            data=data,
             warnings=warnings,
         )
         return 0
@@ -1246,11 +1375,17 @@ def _cmd_search(args: argparse.Namespace) -> int:
     print(f"query={args.query!r}  mode={args.mode}  shown={len(results)}")
     for idx, r in enumerate(results, start=1):
         section = _section_path(r.div1, r.div2, r.div3, r.div4)
-        body = r.content if args.full else _preview(r.content, preview_chars)
         print(f"\n{idx:>2}. book={r.book_id} position={r.position}  title={_single_line(r.title)}")
         print(f"    section={section}")
         print(f"    score={r.score:.2f}  kind={r.kind}  chars={r.char_count}")
-        print(f"    {body}")
+        if radius is None:
+            body = r.content if args.full else _preview(r.content, preview_chars)
+            print(f"    {body}")
+        else:
+            _print_chunk_payload_window(
+                result_windows[idx - 1][0],
+                center_index=result_windows[idx - 1][1],
+            )
         print()
     print(f"{len(results)} result(s)")
     return 0
@@ -1627,6 +1762,8 @@ def _cmd_view(args: argparse.Namespace) -> int:
         )
     if args.n is not None and args.n < 0:
         return _command_error("view", "-n must be >= 0.", as_json=as_json)
+    if args.radius is not None and args.radius < 0:
+        return _command_error("view", "--radius must be >= 0.", as_json=as_json)
     if args.preview and (args.position is None and args.section is None):
         return _command_error(
             "view",
@@ -1641,17 +1778,38 @@ def _cmd_view(args: argparse.Namespace) -> int:
         )
     if args.chars <= 0:
         return _command_error("view", "--chars must be > 0.", as_json=as_json)
+    if args.radius is not None and args.n is not None:
+        return _command_error(
+            "view",
+            (
+                "Choose one retrieval shape: -n for forward chunks "
+                "or -r/--radius for a centered window."
+            ),
+            as_json=as_json,
+        )
+    if args.radius is not None and selected == 0:
+        return _command_error(
+            "view",
+            "--radius requires --position or --section.",
+            as_json=as_json,
+        )
 
     def _effective_n(default: int) -> int:
         return args.n if args.n is not None else default
 
+    def _view_request_shape() -> dict[str, int]:
+        if args.radius is not None:
+            return {"radius": args.radius}
+        return {"n": _effective_n(DEFAULT_VIEW_SELECTOR_N)}
+
     full = not args.preview
     preview_chars = args.chars
+    radius = args.radius
     with Database(args.db) as db:
         if args.position is not None:
-            n = _effective_n(DEFAULT_VIEW_SELECTOR_N)
             anchor = db.chunk_by_position(args.book_id, args.position)
             if anchor is None:
+                n = _effective_n(DEFAULT_VIEW_SELECTOR_N)
                 return _command_error(
                     "view",
                     f"No chunk found at position {args.position} in book {args.book_id}.",
@@ -1660,50 +1818,82 @@ def _cmd_view(args: argparse.Namespace) -> int:
                         "book_id": args.book_id,
                         "mode": "position",
                         "position": args.position,
-                        "n": n,
+                        **_view_request_shape(),
                     },
                 )
-            rows = [row for row in db.chunk_records(args.book_id) if row.position >= args.position]
-            if n > 0:
-                rows = rows[:n]
+            if radius is not None:
+                rows = db.chunk_window(args.book_id, args.position, around=radius)
+                chunks, center_index = _chunk_window_payload(
+                    rows,
+                    center_position=args.position,
+                    full=full,
+                    preview_chars=preview_chars,
+                )
+            else:
+                n = _effective_n(DEFAULT_VIEW_SELECTOR_N)
+                rows = [
+                    row
+                    for row in db.chunk_records(args.book_id)
+                    if row.position >= args.position
+                ]
+                if n > 0:
+                    rows = rows[:n]
             if as_json:
-                _print_json_envelope(
-                    "view",
-                    ok=True,
-                    data={
-                        "book_id": args.book_id,
-                        "mode": "position",
-                        "position": args.position,
-                        "n": n,
-                        "full": full,
-                        "chars": preview_chars,
-                        "count": len(rows),
-                        "chunks": _chunk_rows_json_payload(
-                            rows,
-                            full=full,
-                            preview_chars=preview_chars,
-                        ),
-                    },
-                )
+                data = {
+                    "book_id": args.book_id,
+                    "mode": "position",
+                    "position": args.position,
+                    "full": full,
+                    "chars": preview_chars,
+                    "count": len(rows),
+                }
+                if radius is not None:
+                    data["radius"] = radius
+                    data["center_index"] = center_index
+                    data["chunks"] = chunks
+                else:
+                    data["n"] = n
+                    data["chunks"] = _chunk_rows_json_payload(
+                        rows,
+                        full=full,
+                        preview_chars=preview_chars,
+                    )
+                _print_json_envelope("view", ok=True, data=data)
                 return 0
-            _print_chunk_blocks(
-                rows,
-                full=full,
-                preview_chars=preview_chars,
-                title=(f"book={args.book_id}  position={args.position}  n={n}"),
-                show_meta=bool(args.meta),
-            )
+            if radius is not None:
+                _print_chunk_window(
+                    rows,
+                    center_position=args.position,
+                    full=full,
+                    preview_chars=preview_chars,
+                    title=(
+                        f"book={args.book_id}  position={args.position}  radius={radius}"
+                    ),
+                    show_meta=bool(args.meta),
+                )
+            else:
+                _print_chunk_blocks(
+                    rows,
+                    full=full,
+                    preview_chars=preview_chars,
+                    title=(f"book={args.book_id}  position={args.position}  n={n}"),
+                    show_meta=bool(args.meta),
+                )
             return 0
 
         if args.section is not None:
-            n = _effective_n(DEFAULT_VIEW_SELECTOR_N)
             section_query = args.section.strip()
+            n = _effective_n(DEFAULT_VIEW_SELECTOR_N)
             if not section_query:
                 return _command_error(
                     "view",
                     "--section must not be empty.",
                     as_json=as_json,
-                    data={"book_id": args.book_id, "mode": "section", "n": n},
+                    data={
+                        "book_id": args.book_id,
+                        "mode": "section",
+                        **_view_request_shape(),
+                    },
                 )
 
             section_number: int | None = None
@@ -1719,7 +1909,7 @@ def _cmd_view(args: argparse.Namespace) -> int:
                             "book_id": args.book_id,
                             "mode": "section",
                             "section": section_query,
-                            "n": n,
+                            **_view_request_shape(),
                         },
                     )
                 summary = _build_section_summary(db, args.book_id)
@@ -1733,7 +1923,7 @@ def _cmd_view(args: argparse.Namespace) -> int:
                             "mode": "section",
                             "section": section_query,
                             "section_number": section_number,
-                            "n": n,
+                            **_view_request_shape(),
                         },
                     )
                 raw_sections = summary["sections"]
@@ -1756,7 +1946,7 @@ def _cmd_view(args: argparse.Namespace) -> int:
                                 "max_section_number": len(raw_sections),
                                 "available_sections": examples,
                                 "tip": f"gutenbit toc {args.book_id}",
-                                "n": n,
+                                **_view_request_shape(),
                             },
                         )
                     print(message)
@@ -1781,7 +1971,7 @@ def _cmd_view(args: argparse.Namespace) -> int:
                             "section": section_query,
                             "section_number": section_number,
                             "tip": f"gutenbit toc {args.book_id}",
-                            "n": n,
+                            **_view_request_shape(),
                         },
                     )
                 resolved_section = selected_section["section"].strip()
@@ -1799,13 +1989,11 @@ def _cmd_view(args: argparse.Namespace) -> int:
                             "section": section_query,
                             "section_number": section_number,
                             "tip": f"gutenbit toc {args.book_id}",
-                            "n": n,
+                            **_view_request_shape(),
                         },
                     )
 
             rows = db.chunks_by_div(args.book_id, resolved_section, limit=0)
-            if n > 0:
-                rows = rows[:n]
             if not rows:
                 examples = _section_examples(db, args.book_id)
                 message = (
@@ -1822,7 +2010,7 @@ def _cmd_view(args: argparse.Namespace) -> int:
                             "section": resolved_section,
                             "section_query": section_query,
                             "section_number": section_number,
-                            "n": n,
+                            **_view_request_shape(),
                             "available_sections": examples,
                             "tip": f"gutenbit toc {args.book_id}",
                         },
@@ -1834,38 +2022,62 @@ def _cmd_view(args: argparse.Namespace) -> int:
                         print(f"  {section}")
                 print(f"Tip: run `gutenbit toc {args.book_id}` to list all sections.")
                 return 1
-            if as_json:
-                _print_json_envelope(
-                    "view",
-                    ok=True,
-                    data={
-                        "book_id": args.book_id,
-                        "mode": "section",
-                        "section": resolved_section,
-                        "section_query": section_query,
-                        "section_number": section_number,
-                        "n": n,
-                        "full": full,
-                        "chars": preview_chars,
-                        "count": len(rows),
-                        "chunks": _chunk_rows_json_payload(
-                            rows,
-                            full=full,
-                            preview_chars=preview_chars,
-                        ),
-                    },
+            if radius is not None:
+                center_position = rows[0].position
+                rows = db.chunk_window(args.book_id, center_position, around=radius)
+                chunks, center_index = _chunk_window_payload(
+                    rows,
+                    center_position=center_position,
+                    full=full,
+                    preview_chars=preview_chars,
                 )
+            else:
+                if n > 0:
+                    rows = rows[:n]
+            if as_json:
+                data = {
+                    "book_id": args.book_id,
+                    "mode": "section",
+                    "section": resolved_section,
+                    "section_query": section_query,
+                    "section_number": section_number,
+                    "full": full,
+                    "chars": preview_chars,
+                    "count": len(rows),
+                }
+                if radius is not None:
+                    data["radius"] = radius
+                    data["center_index"] = center_index
+                    data["chunks"] = chunks
+                else:
+                    data["n"] = n
+                    data["chunks"] = _chunk_rows_json_payload(
+                        rows,
+                        full=full,
+                        preview_chars=preview_chars,
+                    )
+                _print_json_envelope("view", ok=True, data=data)
                 return 0
             section_title = (
                 section_query if resolved_section == section_query else resolved_section
             )
-            _print_chunk_blocks(
-                rows,
-                full=full,
-                preview_chars=preview_chars,
-                title=f"book={args.book_id}  section={section_title!r}",
-                show_meta=bool(args.meta),
-            )
+            if radius is not None:
+                _print_chunk_window(
+                    rows,
+                    center_position=rows[center_index].position,
+                    full=full,
+                    preview_chars=preview_chars,
+                    title=f"book={args.book_id}  section={section_title!r}  radius={radius}",
+                    show_meta=bool(args.meta),
+                )
+            else:
+                _print_chunk_blocks(
+                    rows,
+                    full=full,
+                    preview_chars=preview_chars,
+                    title=f"book={args.book_id}  section={section_title!r}",
+                    show_meta=bool(args.meta),
+                )
             return 0
 
         n = _effective_n(DEFAULT_OPENING_CHUNK_COUNT)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -383,6 +383,13 @@ def test_search_help_shows_post_subcommand_global_flags(tmp_path):
     assert "--verbose" in out
 
 
+def test_search_help_documents_radius(tmp_path):
+    code, out, _err = _run_cli(tmp_path / "any.db", "search", "-h")
+    assert code == 0
+    assert "-r" in out
+    assert "--radius" in out
+
+
 def test_search_invalid_fts_syntax_returns_friendly_error(tmp_path):
     db = _make_db(tmp_path)
     db_path = db.path
@@ -392,6 +399,27 @@ def test_search_invalid_fts_syntax_returns_friendly_error(tmp_path):
     assert code == 1
     payload = json.loads(out)
     assert payload["ok"] is False
+    assert payload["errors"] == ["Invalid FTS query syntax: unterminated string."]
+
+
+def test_search_invalid_fts_syntax_with_radius_keeps_radius_in_json(tmp_path):
+    db = _make_db(tmp_path)
+    db_path = db.path
+    db.close()
+
+    code, out, _err = _run_cli(
+        db_path,
+        "search",
+        '"unclosed phrase',
+        "--raw",
+        "--json",
+        "--radius",
+        "2",
+    )
+    assert code == 1
+    payload = json.loads(out)
+    assert payload["ok"] is False
+    assert payload["data"]["radius"] == 2
     assert payload["errors"] == ["Invalid FTS query syntax: unterminated string."]
 
 
@@ -797,6 +825,49 @@ def test_view_position_with_n(tmp_path):
     assert "Call me Ishmael" in out
     assert "It is a way I have of driving off the spleen" in out
     assert "position=" not in out
+
+
+def test_view_position_with_radius_and_meta(tmp_path):
+    db = _make_db(tmp_path)
+    db_path = db.path
+    db.close()
+
+    code, out, _err = _run_cli(
+        db_path,
+        "view",
+        "1",
+        "--position",
+        "1",
+        "-r",
+        "1",
+        "--meta",
+    )
+    assert code == 0
+    assert "radius=1" in out
+    assert "role=center" in out
+    assert "Call me Ishmael" in out
+    assert "CHAPTER 1" in out
+
+
+def test_view_section_with_radius_crosses_section_boundary(tmp_path):
+    db = _make_db(tmp_path)
+    db_path = db.path
+    db.close()
+
+    code, out, _err = _run_cli(
+        db_path,
+        "view",
+        "1",
+        "--section",
+        "2",
+        "-r",
+        "1",
+    )
+    assert code == 0
+    assert "[before]" in out
+    assert "It is a way I have of driving off the spleen" in out
+    assert "[center] CHAPTER 2" in out
+    assert "I stuffed a shirt or two" in out
 
 
 def test_view_section_with_n_and_meta(tmp_path):
@@ -1346,6 +1417,58 @@ def test_view_negative_n_rejected(tmp_path):
     assert "-n must be >= 0." in out
 
 
+def test_search_negative_radius_rejected(tmp_path):
+    db = _make_db(tmp_path)
+    db_path = db.path
+    db.close()
+
+    code, out, _err = _run_cli(db_path, "search", "Ishmael", "--radius", "-1")
+    assert code == 1
+    assert "--radius must be >= 0." in out
+
+
+def test_search_radius_rejected_with_count(tmp_path):
+    db = _make_db(tmp_path)
+    db_path = db.path
+    db.close()
+
+    code, out, _err = _run_cli(db_path, "search", "Ishmael", "--count", "--radius", "1")
+    assert code == 1
+    assert "--radius cannot be used with --count." in out
+
+
+def test_view_negative_radius_rejected(tmp_path):
+    db = _make_db(tmp_path)
+    db_path = db.path
+    db.close()
+
+    code, out, _err = _run_cli(db_path, "view", "1", "--position", "1", "--radius", "-1")
+    assert code == 1
+    assert "--radius must be >= 0." in out
+
+
+def test_view_radius_requires_selector(tmp_path):
+    db = _make_db(tmp_path)
+    db_path = db.path
+    db.close()
+
+    code, out, _err = _run_cli(db_path, "view", "1", "--radius", "1")
+    assert code == 1
+    assert "--radius requires --position or --section." in out
+
+
+def test_view_radius_rejected_with_n(tmp_path):
+    db = _make_db(tmp_path)
+    db_path = db.path
+    db.close()
+
+    code, out, _err = _run_cli(
+        db_path, "view", "1", "--position", "1", "-n", "2", "--radius", "1"
+    )
+    assert code == 1
+    assert "Choose one retrieval shape" in out
+
+
 def test_add_rejects_non_positive_ids(tmp_path):
     code, out, _err = _run_cli(tmp_path / "any.db", "add", "0", "-1")
     assert code == 1
@@ -1388,6 +1511,23 @@ def test_search_json_output(tmp_path):
     assert "score" in result
     assert "kind" in result
     assert "char_count" in result
+
+
+def test_search_json_radius_output(tmp_path):
+    db = _make_db(tmp_path)
+    db_path = db.path
+    db.close()
+
+    code, out, _err = _run_cli(db_path, "search", "Ishmael", "--json", "--radius", "2")
+    assert code == 0
+    payload = json.loads(out)
+    data = payload["data"]
+    assert data["radius"] == 2
+    result = data["items"][0]
+    assert result["center_index"] == 1
+    assert [chunk["position"] for chunk in result["chunks"]] == [0, 1, 2, 3]
+    assert [chunk["role"] for chunk in result["chunks"]] == ["before", "center", "after", "after"]
+    assert result["chunks"][result["center_index"]]["content"].startswith("Call me Ishmael")
 
 
 def test_search_json_empty(tmp_path):
@@ -1589,6 +1729,88 @@ def test_view_section_json_output(tmp_path):
     assert payload["data"]["count"] == 1
     assert payload["data"]["chunks"][0]["content"] == "CHAPTER 1"
     assert payload["data"]["chunks"][0]["kind"] == "heading"
+
+
+def test_view_position_json_radius_output(tmp_path):
+    db = _make_db(tmp_path)
+    db_path = db.path
+    db.close()
+
+    code, out, _err = _run_cli(db_path, "view", "1", "--position", "1", "--radius", "1", "--json")
+    assert code == 0
+    payload = json.loads(out)
+    data = payload["data"]
+    assert data["mode"] == "position"
+    assert data["radius"] == 1
+    assert data["center_index"] == 1
+    assert [chunk["position"] for chunk in data["chunks"]] == [0, 1, 2]
+    assert [chunk["role"] for chunk in data["chunks"]] == ["before", "center", "after"]
+
+
+def test_view_section_json_radius_output(tmp_path):
+    db = _make_db(tmp_path)
+    db_path = db.path
+    db.close()
+
+    code, out, _err = _run_cli(db_path, "view", "1", "--section", "2", "--radius", "1", "--json")
+    assert code == 0
+    payload = json.loads(out)
+    data = payload["data"]
+    assert data["mode"] == "section"
+    assert data["section_number"] == 2
+    assert data["radius"] == 1
+    assert data["center_index"] == 1
+    assert [chunk["position"] for chunk in data["chunks"]] == [2, 3, 4]
+    assert data["chunks"][1]["content"] == "CHAPTER 2"
+
+
+def test_view_position_json_radius_error_keeps_radius(tmp_path):
+    db = _make_db(tmp_path)
+    db_path = db.path
+    db.close()
+
+    code, out, _err = _run_cli(
+        db_path,
+        "view",
+        "1",
+        "--position",
+        "999",
+        "--radius",
+        "2",
+        "--json",
+    )
+    assert code == 1
+    payload = json.loads(out)
+    assert payload["ok"] is False
+    assert payload["data"]["mode"] == "position"
+    assert payload["data"]["position"] == 999
+    assert payload["data"]["radius"] == 2
+    assert "n" not in payload["data"]
+
+
+def test_view_section_json_radius_error_keeps_radius(tmp_path):
+    db = _make_db(tmp_path)
+    db_path = db.path
+    db.close()
+
+    code, out, _err = _run_cli(
+        db_path,
+        "view",
+        "1",
+        "--section",
+        "999",
+        "--radius",
+        "2",
+        "--json",
+    )
+    assert code == 1
+    payload = json.loads(out)
+    assert payload["ok"] is False
+    assert payload["data"]["mode"] == "section"
+    assert payload["data"]["section"] == "999"
+    assert payload["data"]["section_number"] == 999
+    assert payload["data"]["radius"] == 2
+    assert "n" not in payload["data"]
 
 
 def test_view_section_json_meta_output(tmp_path):


### PR DESCRIPTION
## Summary
- add -r/--radius to search for contextual windows around each hit
- add -r/--radius to view for centered windows around --position and --section
- keep JSON consistent with existing ordered chunks payloads, including radius-specific metadata and aligned error envelopes
- update tests, help text, and documentation/examples for the new CLI behavior

## Testing
- uv run pytest tests/test_search.py -q
- uv run ruff check .