### PR TITLE
Simplify CLI radius output and JSON shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ gutenbit catalog --author "Austen, Jane"
 gutenbit add 1342
 gutenbit search "pride"
 gutenbit view 1342 --section 1 -n 5
-gutenbit search "truth universally acknowledged" -n 3 -r 1
+gutenbit search "truth universally acknowledged" -n 3 -r 1   # include surrounding passage
 ```
 
 All commands support `--json` for machine-readable output.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -84,7 +84,7 @@ gutenbit search "ghost OR spirit" --raw                   # FTS5 boolean query
 gutenbit search "Levin" --book-id 1399 --mode first
 gutenbit search "battle" --section "BOOK ONE" --book-id 2600
 gutenbit search "freedom" --kind text -n 5
-gutenbit search "ghost" -n 5 -r 2                        # include neighboring chunks
+gutenbit search "ghost" -n 5 -r 2                        # include surrounding passage
 gutenbit search "ghost" --full -n 3
 gutenbit search "battle" --count
 ```
@@ -101,7 +101,7 @@ gutenbit search "battle" --count
 | `--section SELECTOR` | Restrict to a section by path prefix or number from `toc` (number requires `--book-id`) |
 | `--kind KIND` | Filter by chunk kind: `heading` or `text` |
 | `-n`, `--limit N` | Maximum results (default: 20 for ranked, 1 for first/last) |
-| `-r`, `--radius N` | Neighboring chunks to include on each side of each hit |
+| `-r`, `--radius N` | Surrounding passage chunks to include on each side of each hit |
 | `--count` | Just print the number of matching chunks |
 | `--full` | Print full chunk text instead of previews |
 | `--preview-chars N` | Preview length per result (default: 140) |
@@ -124,7 +124,7 @@ By default, punctuation in the query is auto-escaped so apostrophes, hyphens, an
 ### Result shaping
 
 - Use `-n` to control how many hits are returned.
-- Use `-r` to include context chunks before and after each hit.
+- Use `-r` to read surrounding passage around each hit in normal reading order.
 - `--count` cannot be combined with `-r`.
 
 ### FTS5 query syntax
@@ -169,8 +169,8 @@ gutenbit view 1342 -n 0                         # full text
 gutenbit view 1342 --section 3                  # section by number
 gutenbit view 1342 --section "Chapter 1" -n 10  # section by path
 gutenbit view 1342 --position 50 -n 5           # from exact position
-gutenbit view 1342 --position 50 -r 2           # centered window around position
-gutenbit view 1342 --section 3 -r 2             # centered window around section start
+gutenbit view 1342 --position 50 -r 2           # surrounding passage around position
+gutenbit view 1342 --section 3 -r 2             # surrounding passage around section start
 gutenbit view 1342 --section 3 --meta           # with metadata headers
 gutenbit view 1342 --position 50 --preview --chars 120
 ```
@@ -181,13 +181,13 @@ gutenbit view 1342 --position 50 --preview --chars 120
 | `--section SELECTOR` | Section number (from `toc`) or path prefix (e.g. `"BOOK I/CHAPTER I"`) |
 | `--position N` | Exact chunk position |
 | `-n N` | Chunks to return (default: 3 for opening, 1 for section/position; 0 = all) |
-| `-r`, `--radius N` | Neighboring chunks to include on each side of the selected center chunk |
+| `-r`, `--radius N` | Surrounding passage chunks to include on each side of the selected center chunk |
 | `--preview` | Show truncated previews instead of full text |
 | `--chars N` | Preview length when using `--preview` (default: 140) |
 | `--meta` | Include chunk metadata headers in text output |
 | `--json` | Output as JSON |
 
-Use `--section` or `--position`, not both. `--preview` requires `--section` or `--position`. `-n` and `-r` are mutually exclusive in `view`: `-n` is a forward slice, `-r` is a centered window. Run `toc` first to see available section numbers.
+Use `--section` or `--position`, not both. `--preview` requires `--section` or `--position`. `-n` and `-r` are mutually exclusive in `view`: `-n` is a forward slice, `-r` is a surrounding passage window. Run `toc` first to see available section numbers.
 
 ## JSON output
 
@@ -205,14 +205,14 @@ Every command accepts `--json` and returns a unified envelope:
 
 When `ok` is `false`, the `errors` list contains error messages. The `data` field holds command-specific results. The `warnings` list captures non-fatal issues (e.g. a requested ID not found during bulk delete).
 
-For `view`, chunk-returning modes use an ordered `chunks` array plus mode metadata such as `n` or `radius`. Validation errors preserve that same request-shape metadata in `data` so clients can distinguish forward-slice requests from radius-window requests.
+For `view`, chunk-returning modes use an ordered `chunks` array plus mode metadata such as `n`. Successful radius-window responses use `radius` for the ordered list of chunk positions in the returned passage. Validation errors echo `radius_request` instead of a computed `radius` list.
 
-For `search`, `data["items"]` remains the hit list. When `-r` is used, `data["radius"]` records the requested radius and each item gains:
+For `search`, `data["items"]` remains the hit list. When `-r` is used, each item gains:
 
 - `chunks`: the ordered contextual window for that hit
-- `center_index`: the matched chunk's index within `chunks`
+- `radius`: the ordered list of chunk positions in that window
 
-Each contextual chunk in these arrays includes a `role` field with one of `before`, `center`, or `after`.
+The center chunk is the middle entry in that ordered `radius` list when the full window is available.
 
 ## Global flags
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -75,4 +75,4 @@ Search uses SQLite FTS5 with BM25 ranking. The index is configured with Porter s
 - Unicode normalization handles accented characters and non-ASCII text.
 - Ranking considers term frequency, document length, and inverse document frequency across the corpus.
 
-Search results include the full text of each matching chunk along with its structural metadata, so you can identify where in a book a match occurs without a separate lookup. The CLI can also attach neighboring chunks with `-r/--radius` when you want local reading context around each hit.
+Search results include the full text of each matching chunk along with its structural metadata, so you can identify where in a book a match occurs without a separate lookup. The CLI can also attach surrounding passage with `-r/--radius` when you want local reading context around each hit.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -68,14 +68,14 @@ Read from an exact chunk position:
 gutenbit view 1342 --position 50 -n 5
 ```
 
-Read a centered window around a position or section start:
+Read surrounding passage around a position or section start:
 
 ```bash
 gutenbit view 1342 --position 50 -r 2
 gutenbit view 1342 --section 1 -r 2
 ```
 
-Use `-n` for forward slices and `-r` for symmetric windows. `-n 0` returns all chunks in scope.
+Use `-n` for forward slices and `-r` for surrounding passage windows. `-n 0` returns all chunks in scope.
 
 ### Search
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -198,7 +198,7 @@ window = db.chunk_window(1342, position=50, around=3)
 # Returns chunks at positions 47, 48, 49, 50, 51, 52, 53
 ```
 
-The CLI `view -r/--radius` and `search -r/--radius` options use this same centered-window concept.
+The CLI `view -r/--radius` and `search -r/--radius` options use this same centered-window concept, but present it as a simple surrounding passage in reading order.
 
 **By section path:**
 

--- a/gutenbit/cli.py
+++ b/gutenbit/cli.py
@@ -313,7 +313,6 @@ def _chunk_payload(
     preview_chars: int,
     rank: int | None = None,
     score: float | None = None,
-    role: str | None = None,
 ) -> dict[str, Any]:
     content = row.content if full else _preview(row.content, preview_chars)
     payload = {
@@ -332,8 +331,6 @@ def _chunk_payload(
         payload["rank"] = rank
     if score is not None:
         payload["score"] = round(score, 4)
-    if role is not None:
-        payload["role"] = role
     return payload
 
 
@@ -344,7 +341,7 @@ def _search_result_payload(
     preview_chars: int,
     rank: int,
     chunks: list[dict[str, Any]] | None = None,
-    center_index: int | None = None,
+    radius: list[int] | None = None,
 ) -> dict[str, Any]:
     content = result.content if full else _preview(result.content, preview_chars)
     payload = {
@@ -366,57 +363,44 @@ def _search_result_payload(
     }
     if chunks is not None:
         payload["chunks"] = chunks
-    if center_index is not None:
-        payload["center_index"] = center_index
+    if radius is not None:
+        payload["radius"] = radius
     return payload
 
 
 def _chunk_window_payload(
     rows: list[ChunkRecord],
     *,
-    center_position: int,
     full: bool,
     preview_chars: int,
-) -> tuple[list[dict[str, Any]], int]:
+) -> tuple[list[dict[str, Any]], list[int]]:
     chunks: list[dict[str, Any]] = []
-    center_index = -1
-    for idx, row in enumerate(rows):
-        if row.position < center_position:
-            role = "before"
-        elif row.position > center_position:
-            role = "after"
-        else:
-            role = "center"
-            center_index = idx
+    for row in rows:
         chunks.append(
             _chunk_payload(
                 row,
                 full=full,
                 preview_chars=preview_chars,
-                role=role,
             )
         )
-    return chunks, center_index
+    return chunks, [row.position for row in rows]
 
 
 def _print_chunk_window(
     rows: list[ChunkRecord],
     *,
-    center_position: int,
     full: bool,
     preview_chars: int,
     title: str = "",
     show_meta: bool = False,
 ) -> None:
-    chunks, center_index = _chunk_window_payload(
+    chunks, _ = _chunk_window_payload(
         rows,
-        center_position=center_position,
         full=full,
         preview_chars=preview_chars,
     )
     _print_chunk_payload_window(
         chunks,
-        center_index=center_index,
         title=title,
         show_meta=show_meta,
     )
@@ -425,25 +409,22 @@ def _print_chunk_window(
 def _print_chunk_payload_window(
     chunks: list[dict[str, Any]],
     *,
-    center_index: int,
     title: str = "",
     show_meta: bool = False,
 ) -> None:
-    if title:
-        print(title)
-    for idx, chunk in enumerate(chunks, start=1):
-        role = str(chunk["role"])
-        if show_meta:
+    if show_meta:
+        if title:
+            print(title)
+        for idx, chunk in enumerate(chunks, start=1):
             print(
-                f"\n{idx:>2}. role={role}  position={chunk['position']}  "
+                f"\n{idx:>2}. position={chunk['position']}  "
                 f"kind={chunk['kind']}  chars={chunk['char_count']}"
             )
             print(f"    section={chunk['section']}")
             print(f"    {chunk['content']}")
-            continue
-        marker = "center" if idx - 1 == center_index else role
-        print(f"\n[{marker}] {chunk['content']}")
-    print(f"\n{len(chunks)} chunk(s)")
+        print(f"\n{len(chunks)} chunk(s)")
+        return
+    print("\n\n".join(str(chunk["content"]) for chunk in chunks))
 
 
 def _print_key_value_table(
@@ -699,7 +680,7 @@ examples:
   gutenbit search "door" --mode first                       # reading order (earliest)
   gutenbit search "door" --mode last                        # reverse reading order
   gutenbit search "freedom" --kind text -n 5                # filter by chunk kind
-  gutenbit search "ghost" -n 5 -r 2                         # include neighboring chunks
+  gutenbit search "ghost" -n 5 -r 2                         # show surrounding passage
   gutenbit search "ghost" --full -n 3                       # full chunk text
   gutenbit search "battle" --count                          # just show match count
   gutenbit search "battle" --json                           # JSON output
@@ -770,7 +751,7 @@ tip: use 'gutenbit toc <id>' first to see a book's structure, then
         "--radius",
         type=int,
         default=None,
-        help="neighboring chunks on each side of each hit (default: none)",
+        help="surrounding passage on each side of each hit, in reading order",
     )
     se.add_argument(
         "--count",
@@ -819,7 +800,7 @@ section numbers in this output can be passed to:
             "Read from the first structural section by default, or focus from an exact position "
             "or section selector. Section selectors accept path text or a section "
             "number from `gutenbit toc <book_id>`. Use -n for forward slices "
-            "or -r/--radius for centered windows."
+            "or -r/--radius for surrounding passage windows."
         ),
         epilog="""\
 examples:
@@ -828,10 +809,10 @@ examples:
   gutenbit view 2600 -n 0                            # full reconstructed text
   gutenbit view 2600 --section 3                     # first chunk in section 3
   gutenbit view 2600 --section 3 -n 20               # first 20 chunks in section 3
-  gutenbit view 2600 --section 3 -r 2                # centered window around section start
+  gutenbit view 2600 --section 3 -r 2                # surrounding passage around section start
   gutenbit view 2600 --position 12345                # chunk at position 12345
   gutenbit view 2600 --position 12345 -n 20          # continue reading from position
-  gutenbit view 2600 --position 12345 -r 2           # centered window around position
+  gutenbit view 2600 --position 12345 -r 2           # surrounding passage around position
   gutenbit view 2600 --position 12345 --preview --chars 120
   gutenbit view 2600 --section "BOOK I/CHAPTER I" -n 10 --json
   gutenbit view 2600 --section 3 -n 10 --meta        # include metadata headers
@@ -880,7 +861,7 @@ section hierarchy:  level1 > level2 > level3 > level4  (compacted from shallowes
         "--radius",
         type=int,
         default=None,
-        help="neighboring chunks on each side of the selected center chunk",
+        help="surrounding passage on each side of the selected chunk",
     )
     vw.add_argument(
         "--chars",
@@ -1283,22 +1264,21 @@ def _cmd_search(args: argparse.Namespace) -> int:
                     },
                     "mode": args.mode,
                     "limit": limit,
-                    **({"radius": radius} if radius is not None else {}),
+                    **({"radius_request": radius} if radius is not None else {}),
                 },
                 warnings=warnings,
             )
 
-        result_windows: list[tuple[list[dict[str, Any]], int]] = []
+        result_windows: list[tuple[list[dict[str, Any]], list[int]]] = []
         if radius is not None:
             for result in results:
                 rows = db.chunk_window(result.book_id, result.position, around=radius)
-                chunks, center_index = _chunk_window_payload(
+                chunks, radius_positions = _chunk_window_payload(
                     rows,
-                    center_position=result.position,
                     full=args.full,
                     preview_chars=preview_chars,
                 )
-                result_windows.append((chunks, center_index))
+                result_windows.append((chunks, radius_positions))
 
     # --count: just print the total.
     if args.count:
@@ -1353,13 +1333,11 @@ def _cmd_search(args: argparse.Namespace) -> int:
                     preview_chars=preview_chars,
                     rank=idx,
                     chunks=result_windows[idx - 1][0] if radius is not None else None,
-                    center_index=result_windows[idx - 1][1] if radius is not None else None,
+                    radius=result_windows[idx - 1][1] if radius is not None else None,
                 )
                 for idx, r in enumerate(results, start=1)
             ],
         }
-        if radius is not None:
-            data["radius"] = radius
         _print_json_envelope(
             "search",
             ok=True,
@@ -1384,7 +1362,6 @@ def _cmd_search(args: argparse.Namespace) -> int:
         else:
             _print_chunk_payload_window(
                 result_windows[idx - 1][0],
-                center_index=result_windows[idx - 1][1],
             )
         print()
     print(f"{len(results)} result(s)")
@@ -1783,7 +1760,7 @@ def _cmd_view(args: argparse.Namespace) -> int:
             "view",
             (
                 "Choose one retrieval shape: -n for forward chunks "
-                "or -r/--radius for a centered window."
+                "or -r/--radius for a surrounding passage window."
             ),
             as_json=as_json,
         )
@@ -1799,7 +1776,7 @@ def _cmd_view(args: argparse.Namespace) -> int:
 
     def _view_request_shape() -> dict[str, int]:
         if args.radius is not None:
-            return {"radius": args.radius}
+            return {"radius_request": args.radius}
         return {"n": _effective_n(DEFAULT_VIEW_SELECTOR_N)}
 
     full = not args.preview
@@ -1823,9 +1800,8 @@ def _cmd_view(args: argparse.Namespace) -> int:
                 )
             if radius is not None:
                 rows = db.chunk_window(args.book_id, args.position, around=radius)
-                chunks, center_index = _chunk_window_payload(
+                chunks, radius_positions = _chunk_window_payload(
                     rows,
-                    center_position=args.position,
                     full=full,
                     preview_chars=preview_chars,
                 )
@@ -1848,8 +1824,7 @@ def _cmd_view(args: argparse.Namespace) -> int:
                     "count": len(rows),
                 }
                 if radius is not None:
-                    data["radius"] = radius
-                    data["center_index"] = center_index
+                    data["radius"] = radius_positions
                     data["chunks"] = chunks
                 else:
                     data["n"] = n
@@ -1863,7 +1838,6 @@ def _cmd_view(args: argparse.Namespace) -> int:
             if radius is not None:
                 _print_chunk_window(
                     rows,
-                    center_position=args.position,
                     full=full,
                     preview_chars=preview_chars,
                     title=(
@@ -2025,9 +1999,8 @@ def _cmd_view(args: argparse.Namespace) -> int:
             if radius is not None:
                 center_position = rows[0].position
                 rows = db.chunk_window(args.book_id, center_position, around=radius)
-                chunks, center_index = _chunk_window_payload(
+                chunks, radius_positions = _chunk_window_payload(
                     rows,
-                    center_position=center_position,
                     full=full,
                     preview_chars=preview_chars,
                 )
@@ -2046,8 +2019,7 @@ def _cmd_view(args: argparse.Namespace) -> int:
                     "count": len(rows),
                 }
                 if radius is not None:
-                    data["radius"] = radius
-                    data["center_index"] = center_index
+                    data["radius"] = radius_positions
                     data["chunks"] = chunks
                 else:
                     data["n"] = n
@@ -2064,7 +2036,6 @@ def _cmd_view(args: argparse.Namespace) -> int:
             if radius is not None:
                 _print_chunk_window(
                     rows,
-                    center_position=rows[center_index].position,
                     full=full,
                     preview_chars=preview_chars,
                     title=f"book={args.book_id}  section={section_title!r}  radius={radius}",

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -419,7 +419,7 @@ def test_search_invalid_fts_syntax_with_radius_keeps_radius_in_json(tmp_path):
     assert code == 1
     payload = json.loads(out)
     assert payload["ok"] is False
-    assert payload["data"]["radius"] == 2
+    assert payload["data"]["radius_request"] == 2
     assert payload["errors"] == ["Invalid FTS query syntax: unterminated string."]
 
 
@@ -844,7 +844,7 @@ def test_view_position_with_radius_and_meta(tmp_path):
     )
     assert code == 0
     assert "radius=1" in out
-    assert "role=center" in out
+    assert "position=1" in out
     assert "Call me Ishmael" in out
     assert "CHAPTER 1" in out
 
@@ -864,10 +864,14 @@ def test_view_section_with_radius_crosses_section_boundary(tmp_path):
         "1",
     )
     assert code == 0
-    assert "[before]" in out
     assert "It is a way I have of driving off the spleen" in out
-    assert "[center] CHAPTER 2" in out
+    assert "CHAPTER 2" in out
     assert "I stuffed a shirt or two" in out
+    assert "[before]" not in out
+    assert "[center]" not in out
+    assert "[after]" not in out
+    assert "section='2'" not in out
+    assert "position=" not in out
 
 
 def test_view_section_with_n_and_meta(tmp_path):
@@ -1522,12 +1526,10 @@ def test_search_json_radius_output(tmp_path):
     assert code == 0
     payload = json.loads(out)
     data = payload["data"]
-    assert data["radius"] == 2
     result = data["items"][0]
-    assert result["center_index"] == 1
+    assert result["radius"] == [0, 1, 2, 3]
     assert [chunk["position"] for chunk in result["chunks"]] == [0, 1, 2, 3]
-    assert [chunk["role"] for chunk in result["chunks"]] == ["before", "center", "after", "after"]
-    assert result["chunks"][result["center_index"]]["content"].startswith("Call me Ishmael")
+    assert result["chunks"][1]["content"].startswith("Call me Ishmael")
 
 
 def test_search_json_empty(tmp_path):
@@ -1741,10 +1743,8 @@ def test_view_position_json_radius_output(tmp_path):
     payload = json.loads(out)
     data = payload["data"]
     assert data["mode"] == "position"
-    assert data["radius"] == 1
-    assert data["center_index"] == 1
+    assert data["radius"] == [0, 1, 2]
     assert [chunk["position"] for chunk in data["chunks"]] == [0, 1, 2]
-    assert [chunk["role"] for chunk in data["chunks"]] == ["before", "center", "after"]
 
 
 def test_view_section_json_radius_output(tmp_path):
@@ -1758,8 +1758,7 @@ def test_view_section_json_radius_output(tmp_path):
     data = payload["data"]
     assert data["mode"] == "section"
     assert data["section_number"] == 2
-    assert data["radius"] == 1
-    assert data["center_index"] == 1
+    assert data["radius"] == [2, 3, 4]
     assert [chunk["position"] for chunk in data["chunks"]] == [2, 3, 4]
     assert data["chunks"][1]["content"] == "CHAPTER 2"
 
@@ -1784,8 +1783,7 @@ def test_view_position_json_radius_error_keeps_radius(tmp_path):
     assert payload["ok"] is False
     assert payload["data"]["mode"] == "position"
     assert payload["data"]["position"] == 999
-    assert payload["data"]["radius"] == 2
-    assert "n" not in payload["data"]
+    assert payload["data"]["radius_request"] == 2
 
 
 def test_view_section_json_radius_error_keeps_radius(tmp_path):
@@ -1809,8 +1807,7 @@ def test_view_section_json_radius_error_keeps_radius(tmp_path):
     assert payload["data"]["mode"] == "section"
     assert payload["data"]["section"] == "999"
     assert payload["data"]["section_number"] == 999
-    assert payload["data"]["radius"] == 2
-    assert "n" not in payload["data"]
+    assert payload["data"]["radius_request"] == 2
 
 
 def test_view_section_json_meta_output(tmp_path):


### PR DESCRIPTION
## Summary
- simplify `search -r/--radius` and `view -r/--radius` text output so radius windows read as normal passage text
- align `view --meta` radius output with the existing `view -n --meta` header format
- replace radius JSON role/center metadata with ordered `radius` position lists and use `radius_request` for request-shape error echoes
- refresh CLI help, docs, and examples so the public surface describes surrounding passage consistently
- keep radius tests focused on functional user-facing behavior rather than one-off refactor checks

## Testing
- `uv run pytest`
- `uv run ruff check .`