### PR TITLE
Rename search ordering to order and rank across the API

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -134,7 +134,7 @@ gutenbit search "battle" --count
 | `QUERY` | Search query (positional) |
 | `--phrase` | Treat query as an exact phrase (mutually exclusive with `--raw`) |
 | `--raw` | Pass query directly to FTS5 for advanced syntax (mutually exclusive with `--phrase`) |
-| `--order ORDER` | `ranked` (default), `first`, or `last` |
+| `--order ORDER` | `rank` (default), `first`, or `last` |
 | `--author TEXT` | Filter by author (substring match) |
 | `--title TEXT` | Filter by title (substring match) |
 | `--book ID` | Restrict to a single book |
@@ -155,7 +155,7 @@ By default, punctuation in the query is auto-escaped so apostrophes, hyphens, an
 
 ### Search order
 
-- **ranked**: Results ordered by BM25 relevance score, then book, then position.
+- **rank**: Results ordered by BM25 relevance score, then book, then position.
 - **first**: Earliest matches. Ordered by book ascending, then position ascending.
 - **last**: Latest matches. Ordered by book descending, then position descending.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -170,7 +170,7 @@ for hit in results:
     print(f"{hit.title} | {hit.div1} | {hit.content[:80]}")
 ```
 
-Results are ranked by BM25 relevance. Each `SearchResult` includes the matching text, its structural position (div1 through div4), book metadata, and a relevance score.
+Results use BM25 rank ordering by default. Each `SearchResult` includes the matching text, its structural position (div1 through div4), book metadata, and a relevance score.
 
 ### Read structured chunks
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -116,7 +116,7 @@ db.ingest(books, force=True)  # reprocess even if already current
 results = db.search("battle")
 ```
 
-Returns a list of `SearchResult` objects ranked by BM25 relevance.
+Returns a list of `SearchResult` objects ordered by BM25 rank by default.
 
 **Filters** narrow the result set:
 
@@ -132,7 +132,7 @@ Metadata filters (`author`, `title`, `language`, `subject`) use substring matchi
 **Order** controls result ordering:
 
 ```python
-db.search("battle", order="ranked")  # BM25 score (default)
+db.search("battle", order="rank")    # BM25 score (default)
 db.search("battle", order="first")   # book_id asc, position asc
 db.search("battle", order="last")    # book_id desc, position desc
 ```

--- a/gutenbit/cli.py
+++ b/gutenbit/cli.py
@@ -927,7 +927,7 @@ query modes:
   --raw      FTS5 syntax — AND, OR, NOT, NEAR(), prefix*, "phrases", (groups)
 
 result order:
-  ranked  BM25 rank, then book, then position (default)
+  rank    BM25 rank, then book, then position (default)
   first   book ascending, then position ascending
   last    book descending, then position descending
 
@@ -949,10 +949,10 @@ tip: use 'gutenbit toc <id>' first to see a book's structure, then
     )
     se.add_argument(
         "--order",
-        choices=["ranked", "first", "last"],
-        default="ranked",
+        choices=["rank", "first", "last"],
+        default="rank",
         help=(
-            "search result order: ranked (BM25); "
+            "search result order: rank (BM25); "
             "first (book asc + position asc); "
             "last (book desc + position desc)"
         ),

--- a/gutenbit/db.py
+++ b/gutenbit/db.py
@@ -108,7 +108,7 @@ WHERE chunks_fts MATCH ?
 
 _DIV_TRAILING_PUNCT_RE = re.compile(r"[.,;:!?]+$")
 _DIV_PUNCT_SPACING_RE = re.compile(r"\s*([.,;:!?])\s*")
-SearchOrder = Literal["ranked", "first", "last"]
+SearchOrder = Literal["rank", "first", "last"]
 
 
 def _normalize_div_segment(value: str) -> str:
@@ -549,7 +549,7 @@ class Database:
         subject: str | None = None,
         book_id: int | None = None,
         kind: str | None = None,
-        order: SearchOrder = "ranked",
+        order: SearchOrder = "rank",
         limit: int | None = None,
     ) -> tuple[str, list[object]]:
         """Build the ordered search SQL and params for one search query."""
@@ -564,14 +564,14 @@ class Database:
             sql=_SEARCH_SQL,
         )
 
-        if order == "ranked":
+        if order == "rank":
             sql += " ORDER BY rank, c.book_id, c.position"
         elif order == "first":
             sql += " ORDER BY c.book_id, c.position, rank"
         elif order == "last":
             sql += " ORDER BY c.book_id DESC, c.position DESC, rank"
         else:
-            raise ValueError("order must be one of: ranked, first, last")
+            raise ValueError("order must be one of: rank, first, last")
 
         if limit is not None:
             sql += " LIMIT ?"
@@ -637,7 +637,7 @@ class Database:
         book_id: int | None = None,
         kind: str | None = None,
         div_path: str | None = None,
-        order: SearchOrder = "ranked",
+        order: SearchOrder = "rank",
         limit: int = 20,
     ) -> SearchPage:
         """Return one CLI search page plus an exact total-hit count."""
@@ -708,7 +708,7 @@ class Database:
         book_id: int | None = None,
         kind: str | None = None,
         div_path: str | None = None,
-        order: SearchOrder = "ranked",
+        order: SearchOrder = "rank",
         limit: int = 20,
     ) -> list[SearchResult]:
         """Search chunks via FTS5 with BM25 ranking.

--- a/tests/test_battle.py
+++ b/tests/test_battle.py
@@ -1137,7 +1137,7 @@ class TestCLICommands:
         assert result.returncode == 0
         assert "Scrooge" in result.stdout
         assert "total_results=305  shown_results=10" in result.stdout
-        assert "305 results · 10 shown · ranked order" in result.stdout
+        assert "305 results · 10 shown · rank order" in result.stdout
 
     def test_cli_search_section(self, db_path: str):
         result = _run_cli("search", "Marley", "--section", "STAVE ONE", "--book", "46", db=db_path)

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -41,11 +41,11 @@ def test_format_search_stats_show_total_and_shown_when_limited():
     assert format_search_footer_stats(
         shown_results=10,
         total_results=237,
-        order="ranked",
+        order="rank",
     ) == [
         "237 results",
         "10 shown",
-        "ranked order",
+        "rank order",
     ]
 
 
@@ -112,19 +112,19 @@ def test_rich_search_results_use_visual_header(tmp_path):
 
     CliDisplay(stdout=out, interactive=True, color=False, width=100).search_results(
         query="Ishmael",
-        order="ranked",
+        order="rank",
         items=[item],
         total_results=12,
     )
 
     rendered = out.getvalue()
     assert "Search" in rendered
-    assert 'Query "Ishmael" · ranked · 1 shown' in rendered
+    assert 'Query "Ishmael" · rank · 1 shown' in rendered
     assert "query='Ishmael'" not in rendered
     assert "Score 1.20" in rendered
     assert "Score 1.20\n\nCall me Ishmael." in rendered
     assert "Call me Ishmael." in rendered
-    assert "12 results · 1 shown · ranked order" in rendered
+    assert "12 results · 1 shown · rank order" in rendered
 
 
 def test_rich_passage_separates_title_from_metadata(tmp_path):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -398,7 +398,7 @@ def test_search_help_documents_ordering(tmp_path):
     assert code == 0
     assert "--order" in out
     assert "--mode" not in out
-    assert "ranked" in out and "BM25" in out
+    assert "rank" in out and "BM25" in out
     assert "first" in out and "book ascending" in out
     assert "last" in out and "book descending" in out
 
@@ -505,7 +505,7 @@ def test_search_cli_raw_passes_fts5_syntax(tmp_path):
     code, out, _err = _run_cli(db_path, "search", "Ishmael OR truth", "--raw")
     assert code == 0
     assert "total_results=2  shown_results=2" in out
-    assert "2 results · ranked order" in out
+    assert "2 results · rank order" in out
 
 
 def test_search_cli_rejects_legacy_mode_flag(tmp_path):
@@ -573,7 +573,7 @@ def test_search_cli_footer_shows_total_and_shown_when_limited(tmp_path):
     code, out, _err = _run_cli(db_path, "search", "the", "--book", "1", "--limit", "1")
     assert code == 0
     assert f"total_results={total_results}  shown_results=1" in out
-    assert f"{total_results} results · 1 shown · ranked order" in out
+    assert f"{total_results} results · 1 shown · rank order" in out
 
 
 def test_search_cli_skips_count_for_untruncated_page(tmp_path, monkeypatch):
@@ -2183,7 +2183,7 @@ def test_search_json_output(tmp_path):
 
     data = payload["data"]
     assert data["query"]["raw"] == "Ishmael"
-    assert data["order"] == "ranked"
+    assert data["order"] == "rank"
     assert data["limit"] == 10
     assert data["filters"]["book_id"] is None
     assert "book" not in data["filters"]
@@ -2207,6 +2207,18 @@ def test_search_json_output(tmp_path):
     assert result["kind"] == "text"
     assert "rank" in result
     assert "score" in result
+
+
+def test_search_cli_rejects_removed_default_order_value(tmp_path):
+    db = _make_db(tmp_path)
+    db_path = db.path
+    db.close()
+
+    removed_order = "rank" + "ed"
+    code, out, err = _run_cli(db_path, "search", "Ishmael", "--order", removed_order)
+    assert code == 2
+    assert out == ""
+    assert f"invalid choice: '{removed_order}'" in err
 
 
 def test_search_json_radius_output(tmp_path):


### PR DESCRIPTION
## Summary
- rename the public search ordering surface from `mode` to `order` in the CLI and Python API
- simplify the default order value from `ranked` to `rank` as a hard rename, removing the old token entirely
- update docs and tests to match the cleaned-up terminology and rejection behavior

## Testing
- uv run pytest
- uv run ruff check gutenbit/cli.py gutenbit/db.py tests/test_search.py tests/test_display.py tests/test_battle.py
- uv run ty check