### PR TITLE
Clarify gutenbit's independence from Project Gutenberg

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Full documentation: [Getting Started](docs/getting-started.md) | [Python API](do
 
 ## Project Gutenberg Access
 
-Gutenbit is for individual downloads, not bulk downloading. It prefers official mirrors and uses the main site only as a zip fallback, with a default `2.0` second delay between downloads. Gutenbit also sends an identifying default `User-Agent` on Gutenberg and PGLAF requests: `gutenbit/<version> (+https://gutenbit.textualist.org)`. Review Project Gutenberg's [Robot Access Policy](https://www.gutenberg.org/policy/robot_access.html) and [Terms of Use](https://www.gutenberg.org/policy/terms_of_use.html).
+Gutenbit is an open-source project not affiliated with Project Gutenberg. It is for individual downloads, not bulk downloading. It prefers official mirrors and uses the main site only as a zip fallback, with a default `2.0` second delay between downloads. Gutenbit also sends an identifying default `User-Agent` on Gutenberg and PGLAF requests: `gutenbit/<version> (+https://gutenbit.textualist.org)`. Review Project Gutenberg's [Robot Access Policy](https://www.gutenberg.org/policy/robot_access.html) and [Terms of Use](https://www.gutenberg.org/policy/terms_of_use.html).
 
 ## Development
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,7 +24,7 @@ All CLI-managed state lives under `.gutenbit/` by default: the database is `.gut
 
 ## Project Gutenberg Access
 
-Use gutenbit for individual downloads, not bulk downloading. It prefers official mirrors and uses the main site only as a zip fallback, with a default `2.0` second delay between downloads. Gutenbit also sends an identifying default `User-Agent` on Gutenberg and PGLAF requests: `gutenbit/<version> (+https://gutenbit.textualist.org)`. Review the [Robot Access Policy](https://www.gutenberg.org/policy/robot_access.html) and [Terms of Use](https://www.gutenberg.org/policy/terms_of_use.html).
+Gutenbit is an open-source project not affiliated with Project Gutenberg. It is for individual downloads, not bulk downloading. It prefers official mirrors and uses the main site only as a zip fallback, with a default `2.0` second delay between downloads. Gutenbit also sends an identifying default `User-Agent` on Gutenberg and PGLAF requests: `gutenbit/<version> (+https://gutenbit.textualist.org)`. Review the [Robot Access Policy](https://www.gutenberg.org/policy/robot_access.html) and [Terms of Use](https://www.gutenberg.org/policy/terms_of_use.html).
 
 ## catalog
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,4 +66,4 @@ if book is not None:
 
 ## Project Gutenberg Access
 
-Gutenbit is for individual downloads, not bulk downloading. It prefers official mirrors and uses the main site only as a zip fallback, with a default `2.0` second delay between downloads. Gutenbit also sends an identifying default `User-Agent` on Gutenberg and PGLAF requests: `gutenbit/<version> (+https://gutenbit.textualist.org)`. Review Project Gutenberg's [Robot Access Policy](https://www.gutenberg.org/policy/robot_access.html) and [Terms of Use](https://www.gutenberg.org/policy/terms_of_use.html).
+Gutenbit is an open-source project not affiliated with Project Gutenberg. It is for individual downloads, not bulk downloading. It prefers official mirrors and uses the main site only as a zip fallback, with a default `2.0` second delay between downloads. Gutenbit also sends an identifying default `User-Agent` on Gutenberg and PGLAF requests: `gutenbit/<version> (+https://gutenbit.textualist.org)`. Review Project Gutenberg's [Robot Access Policy](https://www.gutenberg.org/policy/robot_access.html) and [Terms of Use](https://www.gutenberg.org/policy/terms_of_use.html).

--- a/gutenbit/cli.py
+++ b/gutenbit/cli.py
@@ -825,7 +825,10 @@ def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="gutenbit",
         formatter_class=fmt,
-        description="Project Gutenberg ETL — download, chunk, and search public-domain books.",
+        description=(
+            "Fast local search across public-domain literary works. "
+            "Find, browse, and search books from your terminal."
+        ),
         epilog="""\
 typical workflow:
   1. gutenbit catalog --author "Austen, Jane"                       # find Pride and Prejudice
@@ -835,8 +838,8 @@ typical workflow:
   5. gutenbit view 1342 --section 1 --forward 5                     # jump into chapter 1
   6. gutenbit search "truth universally acknowledged" --book 1342 --phrase
 
-chunk kinds:  heading, text
-section hierarchy:  level1 > level2 > level3 > level4  (compacted from shallowest heading)
+Gutenbit is an open-source project not affiliated with Project Gutenberg.
+It is for individual downloads, not bulk downloading.
 
 CLI-managed data is stored under .gutenbit/ (default database: .gutenbit/gutenbit.db).""",
     )


### PR DESCRIPTION
## Summary
- use the standard project description in top-level CLI help
- remove the internal parser notes from that help text
- add explicit non-affiliation language to the Project Gutenberg access sections

## Testing
- not run (not requested)

Refs KEI-55