### PR TITLE
Align GitHub Actions triggers with main-only trunk workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - master
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -2,9 +2,10 @@ name: Package Smoke
 
 on:
   pull_request:
+    branches:
+      - main
   push:
     branches:
-      - develop
       - main
 
 jobs:


### PR DESCRIPTION
### Motivation
- The repository has adopted a trunk-based flow where `main` is the primary branch, so workflow triggers should stop treating `develop` or `master` as first-class branches.
- CI and docs deploy behavior must match the trunk model: PRs target `main`, post-merge validation runs on `main`, docs deploy from `main`, and releases remain tag-driven.

### Description
- Updated ` .github/workflows/package-smoke.yml` to scope `pull_request` events to PRs targeting `main` and removed `develop` from the `push` branch list so `push` runs only on `main`.
- Updated `.github/workflows/docs.yml` to remove the literal `master` branch from the `push` trigger while preserving `main` and `workflow_dispatch`.
- Left `.github/workflows/release.yml` unchanged to preserve the tag-based `v*` release trigger and ensured no workflow files reference `develop` or `master`.

### Testing
- Ran `rg -n "\b(develop|master)\b" .github/workflows` and confirmed there are no matches.
- Reviewed the workflow file diffs to confirm only the trigger blocks were modified and `release.yml` remained untouched.
- Inspected the updated workflow files to verify `pull_request` is scoped to `main`, `push` entries only include `main`, and `workflow_dispatch` remains in `docs.yml`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b22cbca3dc8332af7d0a13a61386b1)