### PR TITLE
docs: inject package version into MkDocs repo label and hide repo stars/forks

### DIFF
--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,0 +1,14 @@
+"""MkDocs hooks for docs-site configuration."""
+
+from __future__ import annotations
+
+from importlib.metadata import version
+from typing import Any
+
+
+def on_config(config: Any, **_: Any) -> Any:
+    """Inject the package version into the repository label."""
+    package_version = version("gutenbit")
+    base_name = config.get("repo_name") or "Gutenbit"
+    config["repo_name"] = f"{base_name} v{package_version}"
+    return config

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -34,3 +34,9 @@
 .md-typeset code {
   border-radius: 4px;
 }
+
+/* Keep only the release tag in the repo metadata pill. */
+.md-source__fact--stars,
+.md-source__fact--forks {
+  display: none;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,9 @@ theme:
 extra_css:
   - stylesheets/extra.css
 
+hooks:
+  - docs/hooks.py
+
 plugins:
   - search
   - gen-files:


### PR DESCRIPTION
### Motivation

- Ensure the docs site repo label includes the package release version so visitors see the current release at a glance.
- Simplify the repo metadata pill by hiding stars and forks to keep the UI focused on the release tag.

### Description

- Add `docs/hooks.py` which defines `on_config(config, **_)` and injects the package version (via `importlib.metadata.version("gutenbit")`) into `config["repo_name"]`.
- Register the hook in `mkdocs.yml` by adding a `hooks` entry that points to `docs/hooks.py`.
- Update `docs/stylesheets/extra.css` to hide the repo stars and forks with rules for `.md-source__fact--stars` and `.md-source__fact--forks` and include a comment explaining the change.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2316ca80483329f21d3104c75d64c)