### PR TITLE
docs: preserve github pages custom domain

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,3 +10,5 @@ Gutenbit uses tag-driven versioning via `hatch-vcs`. Do not edit version strings
 4. Let the `docs` GitHub Actions workflow publish the tagged docs build to the public site.
 
 Installs from `main` are development builds, not stable releases. Docs pushes on `main` are validated but not deployed. If you need to republish docs for an existing release, run the `Manual Docs Deploy` workflow against that release tag. PyPI publication is intentionally not part of this procedure yet.
+
+The GitHub Pages custom domain is tracked in `docs/CNAME` so every docs deploy preserves `gutenbit.textualist.org`.

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+gutenbit.textualist.org


### PR DESCRIPTION
## Summary
- track the GitHub Pages custom domain in `docs/CNAME` so every docs deploy preserves `gutenbit.textualist.org`
- document the custom-domain behavior in `RELEASING.md`

## Testing
- `uv run --extra docs mkdocs build --strict --clean`
- verified `site/CNAME` contains `gutenbit.textualist.org` after the build