### PR TITLE
docs: fix mobile branding regressions

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -169,6 +169,16 @@
   line-height: 1.6;
 }
 
+/* Keep the navigation and TOC panels scrollable without persistent scrollbar chrome. */
+.md-sidebar__scrollwrap {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.md-sidebar__scrollwrap::-webkit-scrollbar {
+  display: none;
+}
+
 @media screen and (max-width: 76.234375em) {
   .md-header__button.md-logo .identity-wordmark {
     --identity-wordmark-size: 23px;

--- a/overrides/partials/header.html
+++ b/overrides/partials/header.html
@@ -7,7 +7,7 @@
 <header class="{{ class }}" data-md-component="header">
   <nav class="md-header__inner md-grid" aria-label="{{ lang.t('header') }}">
     <a href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}" title="{{ config.site_name | e }}" class="md-header__button md-logo" aria-label="{{ config.site_name }}" data-md-component="logo">
-      {% include "partials/logo.html" %}
+      {% include "partials/site-brand.html" %}
     </a>
     <label class="md-header__button md-icon" for="__drawer">
       {% set icon = config.theme.icon.menu or "material/menu" %}

--- a/overrides/partials/logo.html
+++ b/overrides/partials/logo.html
@@ -1,1 +1,0 @@
-{% include "partials/site-brand.html" %}


### PR DESCRIPTION
## Summary
- scope the custom gutenbit wordmark to the desktop header instead of overriding Material's global logo partial
- restore the default drawer logo path so mobile navigation no longer renders repeated unstyled gutenbit titles
- hide the left/right sidebar scrollbar chrome while preserving scroll behavior

## Validation
- uv run --extra docs mkdocs build --strict --clean

Refs KEI-71.