### PR TITLE
Trim user-facing release docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,6 @@ uv run ruff format --check .     # format check
 uv run ty check                  # type check
 ```
 
-## Releases
-
-Versioning is tag-driven via `hatch-vcs`. Merging to `main` does not create a release or require a manual version bump, and installs from `main` are development builds. Cut a release by creating a tag such as `v0.1.6` on the target `main` commit; the release workflow will build the wheel and sdist, validate their metadata, smoke-test the installed wheel, wait for approval on the `pypi` GitHub Actions environment, publish to PyPI with trusted publishing, and then attach the same verified artifacts to GitHub Releases. The docs workflow still publishes the tagged docs build to the public site. Pushes to `main` validate docs but do not publish them. Do not edit version strings in source files. See [RELEASING.md](RELEASING.md).
-
 ## License
 
 MIT

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -191,6 +191,6 @@ text = db.text(1342)
 print(text[:500])
 ```
 
-## What just happened
+## How it works
 
 The pipeline has four stages. The catalog provides book metadata and IDs. The downloader prefers official mirror HTML and falls back to the main site's HTML zip when needed. The chunker parses the HTML using its table of contents as a structural map, turning each paragraph into a discrete chunk with a position and a place in the book's heading hierarchy. The database stores chunks in SQLite with FTS5 indexing for fast full-text search with BM25 ranking.


### PR DESCRIPTION
## Summary
- remove the README Releases section
- retitle the Getting Started closing section to "How it works"

## Testing
- not run (docs-only change)