### PR TITLE
Hide docs header logo on mobile

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -159,32 +159,16 @@
 }
 
 @media screen and (max-width: 76.234375em) {
-  .md-header__button.md-logo img {
-    height: 2.25rem;
-  }
-}
-
-@media screen and (max-width: 59.984375em) {
   .md-header__button.md-logo {
-    margin-left: 0.25rem;
-    margin-right: 0.55rem;
+    display: none;
   }
 
-  .md-header__button.md-logo img {
-    height: 2.1rem;
+  .md-header__title .md-ellipsis {
+    visibility: visible;
   }
 }
 
 @media screen and (max-width: 44.984375em) {
-  .md-header__button.md-logo {
-    margin-left: 0.2rem;
-    margin-right: 0.5rem;
-  }
-
-  .md-header__button.md-logo img {
-    height: 1.95rem;
-  }
-
   .homepage-identity .identity-wordmark {
     --identity-wordmark-size: clamp(34px, 10vw, 50px);
     --identity-wordmark-shift: 1px;

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -20,6 +20,21 @@ DOC_PATHS = (
 _INLINE_COMMENT_RE = re.compile(r"\s+#.*$")
 
 
+def _css_block(css: str, selector: str) -> str:
+    start = css.index(selector)
+    open_brace = css.index("{", start)
+    depth = 0
+    for index in range(open_brace, len(css)):
+        char = css[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return css[open_brace + 1 : index]
+    raise ValueError(f"Unclosed CSS block for {selector!r}")
+
+
 def _extract_cli_commands(path: Path) -> list[str]:
     commands: list[str] = []
     in_bash_block = False
@@ -51,3 +66,11 @@ def test_documented_cli_commands_parse(command: str):
     parser = _build_parser()
     namespace = parser.parse_args(shlex.split(command.removeprefix("gutenbit ")))
     assert namespace.command is not None
+
+
+def test_mobile_header_hides_logo_and_restores_title():
+    css = (REPO_ROOT / "docs" / "stylesheets" / "extra.css").read_text()
+    mobile_header_block = _css_block(css, "@media screen and (max-width: 76.234375em)")
+
+    assert ".md-header__button.md-logo {\n    display: none;\n  }" in mobile_header_block
+    assert ".md-header__title .md-ellipsis {\n    visibility: visible;\n  }" in mobile_header_block


### PR DESCRIPTION
## Summary
- hide the docs header logo at the collapsed/mobile breakpoint
- restore the site title in that header state so the menu icon is first and the title remains visible
- add a focused docs regression test for the mobile header CSS

## Testing
- uv run pytest
- uv run ruff check .
- uv run --extra docs mkdocs build --strict --clean

Closes KEI-90