### PR TITLE
Move default state directory from current working directory to home

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,7 +192,6 @@ cython_debug/
 
 # SQLite databases
 *.db
-.gutenbit/
 
 # Ruff stuff:
 .ruff_cache/

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Or install it like this and then run `gutenbit --help`:
 uv tool install gutenbit
 ```
 
-gutenbit stores its database and catalog cache in a `.gutenbit/` folder.
+gutenbit stores its database and catalog cache in `~/.gutenbit/`.
 
 ## CLI Example
 
@@ -55,8 +55,8 @@ gutenbit search "bennet" --book 1342 --limit 3 --radius 1
 ```
 
 All commands support `--json` for machine-readable output.
-CLI-managed state is stored under `.gutenbit/` by default, including the database at
-`.gutenbit/gutenbit.db` and the catalog cache under `.gutenbit/cache/`.
+CLI-managed state is stored under `~/.gutenbit/` by default, including the database at
+`~/.gutenbit/gutenbit.db` and the catalog cache under `~/.gutenbit/cache/`.
 
 ## Python
 
@@ -73,7 +73,7 @@ catalog = Catalog.fetch()
 book = catalog.get(1342)
 
 if book is not None:
-    with Database(".gutenbit/gutenbit.db") as db:
+    with Database("~/.gutenbit/gutenbit.db") as db:
         db.ingest([book])
         for hit in db.search("truth universally acknowledged", book_id=1342):
             print(hit.title, hit.div1, hit.content[:80])

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,9 +18,9 @@ Or install it like this and then run `gutenbit --help`:
 uv tool install gutenbit
 ```
 
-gutenbit stores its database and catalog cache in a `.gutenbit/` folder.
+gutenbit stores its database and catalog cache in `~/.gutenbit/`.
 
-All CLI-managed state lives under `.gutenbit/` by default: the database is `.gutenbit/gutenbit.db`, and the catalog cache is stored under `.gutenbit/cache/`. Use `--db PATH` to store the database elsewhere. All commands support `--json` for machine-readable output.
+All CLI-managed state lives under `~/.gutenbit/` by default: the database is `~/.gutenbit/gutenbit.db`, and the catalog cache is stored under `~/.gutenbit/cache/`. Use `--db PATH` to store the database elsewhere. All commands support `--json` for machine-readable output.
 
 ## Project Gutenberg Access
 
@@ -257,5 +257,5 @@ These flags apply to all subcommands:
 
 | Flag | Description |
 |------|-------------|
-| `--db PATH` | SQLite database path (default: `.gutenbit/gutenbit.db`) |
+| `--db PATH` | SQLite database path (default: `~/.gutenbit/gutenbit.db`) |
 | `-v`, `--verbose` | Enable debug logging |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,7 +16,7 @@ Or install it like this and then run `gutenbit --help`:
 uv tool install gutenbit
 ```
 
-gutenbit stores its database and catalog cache in a `.gutenbit/` folder.
+gutenbit stores its database and catalog cache in `~/.gutenbit/`.
 
 ## CLI walkthrough
 
@@ -46,7 +46,7 @@ Pass one or more Project Gutenberg IDs to `add`:
 gutenbit add 1342
 ```
 
-The book's HTML is downloaded, parsed into paragraph-level chunks with structural metadata, and stored in a local SQLite database (`.gutenbit/gutenbit.db` by default).
+The book's HTML is downloaded, parsed into paragraph-level chunks with structural metadata, and stored in a local SQLite database (`~/.gutenbit/gutenbit.db` by default).
 
 ### Explore structure
 
@@ -150,14 +150,14 @@ for book in books[:5]:
     print(book.id, book.title)
 ```
 
-The catalog is cached locally for two hours under `.gutenbit/cache/`, filtered to English text, and deduplicated by normalized title plus primary author, keeping the lowest Project Gutenberg ID as canonical. Use `--refresh` to force a redownload.
+The catalog is cached locally for two hours under `~/.gutenbit/cache/`, filtered to English text, and deduplicated by normalized title plus primary author, keeping the lowest Project Gutenberg ID as canonical. Use `--refresh` to force a redownload.
 
 ### Ingest books
 
 ```python
 from gutenbit import Database
 
-with Database(".gutenbit/gutenbit.db") as db:
+with Database("~/.gutenbit/gutenbit.db") as db:
     db.ingest(books[:3])
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ Or install it like this and then run `gutenbit --help`:
 uv tool install gutenbit
 ```
 
-gutenbit stores its database and catalog cache in a `.gutenbit/` folder.
+gutenbit stores its database and catalog cache in `~/.gutenbit/`.
 
 ## CLI Example
 
@@ -51,8 +51,8 @@ gutenbit search "bennet" --book 1342 --limit 3 --radius 1
 ```
 
 All commands support `--json` for machine-readable output.
-CLI-managed state is stored under `.gutenbit/` by default, including the database at
-`.gutenbit/gutenbit.db` and the catalog cache under `.gutenbit/cache/`.
+CLI-managed state is stored under `~/.gutenbit/` by default, including the database at
+`~/.gutenbit/gutenbit.db` and the catalog cache under `~/.gutenbit/cache/`.
 
 ## Python
 
@@ -69,7 +69,7 @@ catalog = Catalog.fetch()
 book = catalog.get(1342)
 
 if book is not None:
-    with Database(".gutenbit/gutenbit.db") as db:
+    with Database("~/.gutenbit/gutenbit.db") as db:
         db.ingest([book])
         for hit in db.search("truth universally acknowledged", book_id=1342):
             print(hit.title, hit.div1, hit.content[:80])

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -78,7 +78,7 @@ See the [API Reference](reference/gutenbit/catalog.md) for full details on `Cata
 ```python
 from gutenbit import Database
 
-with Database(".gutenbit/gutenbit.db") as db:
+with Database("~/.gutenbit/gutenbit.db") as db:
     # all operations here
     ...
 ```
@@ -91,7 +91,7 @@ Or manage the connection manually with `db.close()`.
 catalog = Catalog.fetch()
 books = catalog.search(author="Tolstoy")
 
-with Database(".gutenbit/gutenbit.db") as db:
+with Database("~/.gutenbit/gutenbit.db") as db:
     db.ingest(books)
 ```
 

--- a/gutenbit/_cache.py
+++ b/gutenbit/_cache.py
@@ -2,17 +2,13 @@
 
 from __future__ import annotations
 
-import os
 import tempfile
 from pathlib import Path
 
 
 def default_cache_dir() -> Path:
     """Return the default user cache directory for gutenbit."""
-    cache_home = os.environ.get("XDG_CACHE_HOME")
-    if cache_home:
-        return Path(cache_home) / "gutenbit"
-    return Path.home() / ".cache" / "gutenbit"
+    return Path.home() / ".gutenbit" / "cache"
 
 
 def read_cache_bytes(path: Path) -> bytes | None:

--- a/gutenbit/cli.py
+++ b/gutenbit/cli.py
@@ -27,7 +27,7 @@ from gutenbit.download import describe_download_source, get_last_download_source
 
 STATE_DIR_NAME = ".gutenbit"
 DEFAULT_DB_NAME = "gutenbit.db"
-DEFAULT_DB = f"{STATE_DIR_NAME}/{DEFAULT_DB_NAME}"
+DEFAULT_DB = f"~/{STATE_DIR_NAME}/{DEFAULT_DB_NAME}"
 DEFAULT_DOWNLOAD_DELAY = 2.0
 DEFAULT_TOC_EXPAND = "2"
 JSON_OPENING_LINE_PREVIEW_CHARS = 140
@@ -96,7 +96,7 @@ def _display() -> CliDisplay:
 
 
 def _cli_state_dir() -> Path:
-    return (Path.cwd() / STATE_DIR_NAME).resolve()
+    return Path.home() / STATE_DIR_NAME
 
 
 def _catalog_cache_dir() -> Path:
@@ -855,7 +855,7 @@ gutenbit is an open-source project not affiliated with Project Gutenberg.
 It is for individual downloads, not bulk downloading.
 
 By default, gutenbit stores its SQLite database and catalog cache in
-.gutenbit/ in the current directory (default database: .gutenbit/gutenbit.db).""",
+~/.gutenbit/ (default database: ~/.gutenbit/gutenbit.db).""",
     )
     p._optionals.title = "global options"
     p.add_argument("--db", default=DEFAULT_DB, help="SQLite database path (default: %(default)s)")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import io
+from pathlib import Path
 
 import pytest
 
@@ -78,7 +79,7 @@ def test_help_shows_project_local_default_db():
 
     assert excinfo.value.code == 0
     assert err.getvalue() == ""
-    assert ".gutenbit/gutenbit.db" in out.getvalue()
+    assert "~/.gutenbit/gutenbit.db" in out.getvalue()
 
 
 def test_help_shows_pride_and_prejudice_workflow():
@@ -151,8 +152,9 @@ def test_delete_subcommand_is_rejected():
     assert "remove" in err
 
 
-def test_books_creates_default_db_under_project_state_dir(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
+def test_books_creates_default_db_under_home_state_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
 
     code, out, err = _run_cli("books")
 
@@ -168,10 +170,11 @@ def test_default_cli_db_does_not_auto_discover_legacy_root_db(tmp_path, monkeypa
     with Database(legacy_db) as db:
         db._store(_BOOK, chunk_html(_BOOK_HTML))
 
-    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
 
     code, out, err = _run_cli("books")
-    explicit_code, explicit_out, explicit_err = _run_cli("--db", "gutenbit.db", "books")
+    explicit_code, explicit_out, explicit_err = _run_cli("--db", str(legacy_db), "books")
 
     assert code == 0
     assert err == ""
@@ -180,4 +183,4 @@ def test_default_cli_db_does_not_auto_discover_legacy_root_db(tmp_path, monkeypa
 
     assert explicit_code == 0
     assert explicit_err == ""
-    assert "1 book(s) stored in gutenbit.db" in explicit_out
+    assert f"1 book(s) stored in {legacy_db}" in explicit_out

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -8,6 +8,7 @@ import os
 import shlex
 import time
 import zipfile
+from pathlib import Path
 
 import httpx
 import pytest
@@ -1829,7 +1830,7 @@ def test_catalog_fetch_enforces_english_text_policy_and_canonical_ids(tmp_path, 
             return None
 
     compressed = gzip.compress(csv_payload.encode("utf-8"))
-    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
     calls: list[dict[str, object]] = []
 
     def _fake_get(*_args, **kwargs: object) -> _FakeResponse:
@@ -1866,7 +1867,7 @@ def test_catalog_fetch_uses_fresh_cache_without_network(tmp_path, monkeypatch):
         ]
     )
     compressed = gzip.compress(csv_payload.encode("utf-8"))
-    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
 
     class _FakeResponse:
         def __init__(self, content: bytes):
@@ -1901,7 +1902,7 @@ def test_catalog_fetch_redownloads_when_cache_is_older_than_two_hours(tmp_path, 
         ]
     )
     compressed = gzip.compress(csv_payload.encode("utf-8"))
-    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
 
     class _FakeResponse:
         def __init__(self, content: bytes):
@@ -1919,7 +1920,8 @@ def test_catalog_fetch_redownloads_when_cache_is_older_than_two_hours(tmp_path, 
     monkeypatch.setattr("gutenbit.catalog.httpx.get", _fake_get)
 
     initial = Catalog.fetch()
-    payload_path = next((tmp_path / "gutenbit").glob("*.csv.gz"))
+    cache_dir = tmp_path / ".gutenbit" / "cache"
+    payload_path = next(cache_dir.glob("*.csv.gz"))
     stale_timestamp = time.time() - (2 * 60 * 60 + 1)
     os.utime(payload_path, (stale_timestamp, stale_timestamp))
     refreshed = Catalog.fetch()
@@ -1939,7 +1941,7 @@ def test_catalog_fetch_falls_back_to_cached_payload_on_network_error(tmp_path, m
         ]
     )
     compressed = gzip.compress(csv_payload.encode("utf-8"))
-    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
 
     class _FakeResponse:
         def __init__(self, content: bytes):
@@ -1954,7 +1956,8 @@ def test_catalog_fetch_falls_back_to_cached_payload_on_network_error(tmp_path, m
     )
 
     initial = Catalog.fetch()
-    payload_path = next((tmp_path / "gutenbit").glob("*.csv.gz"))
+    cache_dir = tmp_path / ".gutenbit" / "cache"
+    payload_path = next(cache_dir.glob("*.csv.gz"))
     stale_timestamp = time.time() - (2 * 60 * 60 + 1)
     os.utime(payload_path, (stale_timestamp, stale_timestamp))
     monkeypatch.setattr(
@@ -1979,7 +1982,7 @@ def test_catalog_fetch_refresh_bypasses_fresh_cache(tmp_path, monkeypatch):
         ]
     )
     compressed = gzip.compress(csv_payload.encode("utf-8"))
-    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
 
     class _FakeResponse:
         def __init__(self, content: bytes):
@@ -2030,7 +2033,7 @@ def test_catalog_cli_uses_project_local_cache_dir_and_reports_cache_hit(tmp_path
         )
 
     monkeypatch.setattr("gutenbit.cli.Catalog.fetch", staticmethod(_fake_fetch))
-    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
 
     code, out, _err = _run_cli(
         tmp_path / "nested" / "library.db",
@@ -2070,7 +2073,7 @@ def test_catalog_cli_refresh_flag_forces_redownload_message(tmp_path, monkeypatc
         )
 
     monkeypatch.setattr("gutenbit.cli.Catalog.fetch", staticmethod(_fake_fetch))
-    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
 
     code, out, _err = _run_cli(
         tmp_path / "nested" / "library.db",


### PR DESCRIPTION
## Summary
This PR changes gutenbit's default state directory from `.gutenbit/` in the current working directory to `~/.gutenbit/` in the user's home directory. This aligns with standard Unix conventions for user-specific application data and provides a more predictable, consistent location for the database and cache across different working directories.

## Key Changes

- **Cache directory**: Updated `default_cache_dir()` in `_cache.py` to use `~/.gutenbit/cache` instead of `XDG_CACHE_HOME`-based paths
- **CLI state directory**: Changed `_cli_state_dir()` to return `Path.home() / ".gutenbit"` instead of `Path.cwd() / ".gutenbit"`
- **Default database path**: Updated `DEFAULT_DB` constant to use `~/.gutenbit/gutenbit.db` format
- **Test updates**: Modified test fixtures to mock `Path.home()` instead of using `monkeypatch.chdir()` or `XDG_CACHE_HOME` environment variables
- **Documentation**: Updated all references in README, docs, and docstrings to reflect the new `~/.gutenbit/` location
- **Gitignore**: Removed `.gutenbit/` entry since it's no longer in the project directory

## Implementation Details

- Tests now use `monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))` to mock the home directory, providing better isolation and clarity about what's being tested
- The cache directory structure changed from `XDG_CACHE_HOME/gutenbit` to `~/.gutenbit/cache`
- All user-facing documentation and help text updated to show the new paths with `~/` notation

https://claude.ai/code/session_01EL6hTN7gga9MiAfP2kj3xa