### PR TITLE
Update gutenbit --help copy and default DB path wording

### DIFF
--- a/gutenbit/cli.py
+++ b/gutenbit/cli.py
@@ -861,7 +861,8 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="gutenbit",
         formatter_class=fmt,
         description=(
-            "Find, store, inspect, read, and search Project Gutenberg books from your terminal."
+            "A tool for fast local search across public-domain literary works. "
+            "Find, browse and search books from your terminal."
         ),
         epilog="""\
 quick start:
@@ -874,14 +875,16 @@ quick start:
 learn more:
   gutenbit COMMAND --help    detailed help for one command
 
-gutenbit is an open-source project not affiliated with Project Gutenberg.
-It is for individual downloads, not bulk downloading.
-
-By default, gutenbit stores its SQLite database and catalog cache in
-~/.gutenbit/ (default database: ~/.gutenbit/gutenbit.db).""",
+gutenbit is an open-source project not affiliated with Project Gutenberg. It is for
+individual downloads, not bulk downloading. By default, all application data is
+stored at ~/.gutenbit.""",
     )
     p._optionals.title = "global options"
-    p.add_argument("--db", default=DEFAULT_DB, help="SQLite database path (default: %(default)s)")
+    p.add_argument(
+        "--db",
+        default=DEFAULT_DB,
+        help="SQLite database path (default: ~/.gutenbit/gutenbit.db)",
+    )
     p.add_argument("--version", action="version", version=f"%(prog)s {_package_version()}")
     p.add_argument("-v", "--verbose", action="store_true", help="enable debug logging")
     sub = p.add_subparsers(dest="command", title="commands", metavar="COMMAND")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import re
 import io
 from pathlib import Path
 
@@ -125,7 +126,9 @@ def test_help_uses_command_placeholder_instead_of_choice_braces():
     assert "project gutenberg:" not in rendered
     assert "local state:" not in rendered
     assert "not affiliated with Project Gutenberg" in rendered
-    assert "stores its SQLite database and catalog cache in" in rendered
+    normalized = re.sub(r"\s+", " ", rendered)
+    assert "all application data is stored at ~/.gutenbit" in normalized
+    assert "SQLite database path (default: ~/.gutenbit/gutenbit.db)" in rendered
 
 
 def test_display_cli_path_preserves_relative_and_home_relative_paths():


### PR DESCRIPTION
### Motivation
- Refresh the top-level CLI help copy to better describe the tool as a fast local search over public-domain works and clarify where application data is stored by default.
- Make the `--db` option help explicit about the default SQLite path to reduce user confusion.

### Description
- Replaced the `description` text in `gutenbit/cli.py` with: "A tool for fast local search across public-domain literary works. Find, browse and search books from your terminal.".
- Consolidated the epilog compliance paragraph into a single sentence stating: "By default, all application data is stored at ~/.gutenbit." and wrapped the string for linting.
- Updated the global `--db` argument help to `"SQLite database path (default: ~/.gutenbit/gutenbit.db)"` so the default path is explicit.
- Adjusted `tests/test_cli.py` to validate the new help copy and to normalize whitespace when asserting against wrapped help output.

### Testing
- Ran the full unit test suite with `uv run pytest` which selected 330 tests and reported 2 failures (an unrelated preexisting failure in `tests/test_display.py::test_rich_section_summary_uses_simple_section_layout`); the help-related failure was addressed by the change.
- Ran the focused CLI tests with `uv run pytest tests/test_cli.py -q` which passed (15 passed).
- Ran lint and formatting checks with `uv run ruff check .` and `uv run ruff format --check .`, both of which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4c61abf74833287ebd3e4832a778a)