### PR TITLE
Simplify html_chunker: remove redundant state and dead code

### DIFF
--- a/gutenbit/html_chunker/__init__.py
+++ b/gutenbit/html_chunker/__init__.py
@@ -79,17 +79,13 @@ def chunk_html(html: str) -> list[Chunk]:
     """
     soup = BeautifulSoup(html, HTML_PARSER_BACKEND)
     doc_index = _scan_document(soup)
-    bounds = doc_index.bounds
     tag_positions = doc_index.tag_positions
 
     # Build section list from TOC links and refine with body headings when the
     # TOC is a coarse but valid subsequence of the body structure.
-    toc_sections = _parse_toc_sections(doc_index=doc_index, bounds=bounds)
+    toc_sections = _parse_toc_sections(doc_index=doc_index)
     if toc_sections:
-        heading_sections = _parse_heading_sections(
-            doc_index=doc_index,
-            bounds=bounds,
-        )
+        heading_sections = _parse_heading_sections(doc_index=doc_index)
         sections = _refine_toc_sections(
             toc_sections,
             heading_sections,
@@ -97,7 +93,7 @@ def chunk_html(html: str) -> list[Chunk]:
         )
     else:
         # Some Gutenberg editions expose page-number TOC links only.
-        sections = _parse_heading_sections(doc_index=doc_index, bounds=bounds)
+        sections = _parse_heading_sections(doc_index=doc_index)
     if not sections:
         return []
 
@@ -116,16 +112,21 @@ def chunk_html(html: str) -> list[Chunk]:
     pos = 0
     divs = ["", "", "", ""]
 
+    # Precompute the heading element (or anchor itself) for each section,
+    # avoiding redundant find_parent calls in the loop below.
+    def _heading_or_anchor(anchor: Tag) -> Tag:
+        return anchor.find_parent(_HEADING_TAGS) or anchor
+
+    section_els = [_heading_or_anchor(s.body_anchor) for s in sections]
+
     # Opening paragraphs before first section remain unsectioned prose.
     heading_texts = {s.heading_text.lower() for s in sections}
-    first_heading = sections[0].body_anchor.find_parent(_HEADING_TAGS)
-    stop_tag = first_heading or sections[0].body_anchor
-    stop_pos = tag_positions.get(id(stop_tag))
+    stop_pos = tag_positions.get(id(section_els[0]))
     if stop_pos is not None:
         for text in _paragraphs_in_range(
             doc_index.paragraphs,
             doc_index.paragraph_positions,
-            bounds.start_pos,
+            doc_index.bounds.start_pos,
             stop_pos,
             heading_texts=heading_texts,
             min_length=20,
@@ -139,6 +140,9 @@ def chunk_html(html: str) -> list[Chunk]:
     tail_anchor = _find_non_structural_boundary_after(
         sections[-1].body_anchor, doc_index=doc_index
     )
+    tail_pos: int | None = None
+    if tail_anchor is not None:
+        tail_pos = tag_positions.get(id(_heading_or_anchor(tail_anchor)))
 
     # Body sections.
     for i, section in enumerate(sections):
@@ -154,20 +158,14 @@ def chunk_html(html: str) -> list[Chunk]:
         pos += 1
 
         # Paragraphs until next section (or tail boundary for the last section).
-        heading_el = section.body_anchor.find_parent(_HEADING_TAGS)
-        start_el = heading_el or section.body_anchor
-        start_pos_val = tag_positions.get(id(start_el))
+        start_pos_val = tag_positions.get(id(section_els[i]))
 
-        stop_pos_val: int | None = None
         if i + 1 < len(sections):
-            next_heading = sections[i + 1].body_anchor.find_parent(_HEADING_TAGS)
-            next_stop = next_heading or sections[i + 1].body_anchor
-            stop_pos_val = tag_positions.get(id(next_stop))
-        elif tail_anchor is not None:
-            tail_heading = tail_anchor.find_parent(_HEADING_TAGS)
-            is_heading_tag = tail_heading and tail_heading.name in _HEADING_TAGS
-            tail_stop = tail_heading if is_heading_tag else tail_anchor
-            stop_pos_val = tag_positions.get(id(tail_stop))
+            stop_pos_val = tag_positions.get(id(section_els[i + 1]))
+        elif tail_pos is not None:
+            stop_pos_val = tail_pos
+        else:
+            stop_pos_val = None
 
         if start_pos_val is not None:
             for text in _paragraphs_in_range(

--- a/gutenbit/html_chunker/_scanning.py
+++ b/gutenbit/html_chunker/_scanning.py
@@ -55,7 +55,6 @@ class _DocumentIndex:
     heading_positions: list[int]
     toc_links: list[Tag]
     anchor_map: dict[str, Tag]
-    all_heading_tags: list[Tag]
     bounds: _ContentBounds
 
 
@@ -263,7 +262,6 @@ def _scan_document(soup: BeautifulSoup) -> _DocumentIndex:
         heading_positions=heading_positions,
         toc_links=toc_links,
         anchor_map=anchor_map,
-        all_heading_tags=all_heading_tags,
         bounds=bounds,
     )
 

--- a/gutenbit/html_chunker/_sections.py
+++ b/gutenbit/html_chunker/_sections.py
@@ -18,7 +18,6 @@ from gutenbit.html_chunker._common import (
     _PLAY_HEADING_PARAGRAPH_RE,
     _STANDALONE_STRUCTURAL_RE,
     _clean_heading_text,
-    _ContentBounds,
     _extract_heading_text,
     _heading_tag_rank,
     _HeadingRow,
@@ -94,10 +93,10 @@ _TAIL_SECTION_HEADING_RE = re.compile(
 def _parse_toc_sections(
     *,
     doc_index: _DocumentIndex,
-    bounds: _ContentBounds,
 ) -> list[_Section]:
     """Extract section list from TOC ``pginternal`` links."""
     tag_positions = doc_index.tag_positions
+    bounds = doc_index.bounds
     toc_links = doc_index.toc_links
     sections: list[_Section] = []
     used_headings: set[int] = set()
@@ -310,27 +309,24 @@ def _respect_heading_rank_nesting(sections: list[_Section]) -> list[_Section]:
 def _parse_heading_sections(
     *,
     doc_index: _DocumentIndex,
-    bounds: _ContentBounds,
 ) -> list[_Section]:
     """Fallback section extraction directly from body headings.
 
     Used when TOC links don't point at structural anchors (e.g., page-number
     links only). We start from the first heading that looks structural.
     """
+    bounds = doc_index.bounds
     heading_rows: list[_HeadingRow] = []
-    for heading in doc_index.all_heading_tags:
-        if not _tag_within_bounds(heading, doc_index.tag_positions, bounds):
+    for ih in doc_index.headings:
+        if not bounds.contains(ih.position):
             continue
-        heading_text = _clean_heading_text(_extract_heading_text(heading))
-        if not heading_text:
+        if _is_non_structural_heading_text(ih.text):
             continue
-        if _is_non_structural_heading_text(heading_text):
-            continue
-        rank = _heading_tag_rank(heading)
+        rank = _heading_tag_rank(ih.tag)
         if rank is None:
             continue
-        anchor = heading.find("a", id=True) or heading
-        heading_rows.append(_HeadingRow(heading, anchor, heading_text, rank))
+        anchor = ih.tag.find("a", id=True) or ih.tag
+        heading_rows.append(_HeadingRow(ih.tag, anchor, ih.text, rank))
 
     if _should_scan_paragraph_heading_rows(heading_rows, doc_index.paragraphs):
         heading_rows.extend(_paragraph_heading_rows(doc_index))

--- a/gutenbit/html_chunker/_toc.py
+++ b/gutenbit/html_chunker/_toc.py
@@ -8,12 +8,10 @@ from bs4 import Tag
 
 from gutenbit.html_chunker._common import (
     _FRONT_MATTER_HEADINGS,
-    _HEADING_TAGS,
     _NON_ALNUM_RE,
     _NUMERIC_LINK_TEXT_RE,
     _ROMAN_NUMERAL_RE,
     _clean_heading_text,
-    _extract_heading_text,
     _front_matter_heading_key,
 )
 from gutenbit.html_chunker._headings import (
@@ -71,30 +69,21 @@ def _looks_enumerated_toc_entry(text: str) -> bool:
     return _ROMAN_NUMERAL_RE.fullmatch(first_token) is not None or first_token.isdigit()
 
 
-def _previous_heading_text(link: Tag, *, doc_index: _DocumentIndex | None = None) -> str:
+def _previous_heading_text(link: Tag, *, doc_index: _DocumentIndex) -> str:
     """Return the nearest preceding heading text, if any.
 
-    When *doc_index* is provided, uses the precomputed heading index with
-    bisect for O(log n) lookup instead of O(n) backward DOM traversal.
+    Uses the precomputed heading index with bisect for O(log n) lookup.
     """
-    if doc_index is not None:
-        link_pos = doc_index.tag_positions.get(id(link))
-        if link_pos is not None and doc_index.heading_positions:
-            idx = bisect_left(doc_index.heading_positions, link_pos) - 1  # last heading strictly before link_pos
-            if idx >= 0:
-                return doc_index.headings[idx].text
-        return ""
-    for heading in link.find_all_previous(_HEADING_TAGS):
-        if not isinstance(heading, Tag):
-            continue
-        text = _clean_heading_text(_extract_heading_text(heading))
-        if text:
-            return text
+    link_pos = doc_index.tag_positions.get(id(link))
+    if link_pos is not None and doc_index.heading_positions:
+        idx = bisect_left(doc_index.heading_positions, link_pos) - 1  # last heading strictly before link_pos
+        if idx >= 0:
+            return doc_index.headings[idx].text
     return ""
 
 
 def _is_structural_toc_link(
-    link: Tag, link_text: str | None = None, *, doc_index: _DocumentIndex | None = None
+    link: Tag, link_text: str, *, doc_index: _DocumentIndex
 ) -> bool:
     """Return True for TOC links that can map to actual section headings."""
     if not _is_toc_context_link(link):
@@ -129,8 +118,6 @@ def _is_structural_toc_link(
     if link.find_parent("span", class_="pagenum"):
         return False
 
-    if link_text is None:
-        link_text = _clean_heading_text(" ".join(link.get_text().split()))
     if not link_text:
         return False
     if _NUMERIC_LINK_TEXT_RE.fullmatch(link_text):


### PR DESCRIPTION
## Summary

- **Remove `all_heading_tags` from `_DocumentIndex`** — `_parse_heading_sections` now uses the precomputed `headings` index directly, avoiding redundant `_extract_heading_text` + `_clean_heading_text` calls on every heading tag
- **Remove redundant `bounds` parameter** from `_parse_toc_sections` and `_parse_heading_sections` — already accessible via `doc_index.bounds`
- **Remove dead fallback code in `_toc.py`** — make `doc_index` and `link_text` required in `_previous_heading_text` and `_is_structural_toc_link`, dropping unused O(n) DOM-traversal fallback and two unused imports
- **Precompute `section_els`** in `chunk_html` to eliminate ~2N redundant `find_parent(_HEADING_TAGS)` DOM walks in the main chunk loop
- **Simplify tail-boundary handling** — remove redundant `is_heading_tag` guard (guaranteed true by `find_parent`)

Net: **-21 lines**, no behavioral changes.

## Test plan

- [x] All 330 unit tests pass
- [x] All 35 network regression tests pass (`uv run pytest -m network`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)