### PR TITLE
Simplify CLI module: remove re-exports, dead code, misplaced utility

### DIFF
--- a/gutenbit/cli/__init__.py
+++ b/gutenbit/cli/__init__.py
@@ -18,43 +18,17 @@ from gutenbit.cli._commands import (
     _cmd_toc,
     _cmd_view,
 )
-
-# ---------------------------------------------------------------------------
-# Re-exports: these names are imported by tests and other consumers from
-# gutenbit.cli — keep them accessible here.
-# ---------------------------------------------------------------------------
-from gutenbit.catalog import Catalog as Catalog  # noqa: F401
-from gutenbit.cli._context import (  # noqa: F401
+from gutenbit.catalog import Catalog as Catalog  # noqa: F401 — tests monkeypatch gutenbit.cli.Catalog.fetch
+from gutenbit.cli._context import (
     _CONTEXT_SETTINGS,
     _DB_HELP,
     _VERBOSE_HELP,
     DEFAULT_DB,
     _display,
-    _display_cli_path,
 )
-from gutenbit.cli._json import (  # noqa: F401
-    _passage_payload,
-    _print_json_envelope,
-)
-from gutenbit.cli._sections import _build_section_summary  # noqa: F401
-from gutenbit.cli._text_utils import _select_section_opening_line  # noqa: F401
+from gutenbit.cli._json import _print_json_envelope
 
-__all__ = [
-    "Catalog",
-    "DEFAULT_DB",
-    "_CONTEXT_SETTINGS",
-    "_DB_HELP",
-    "_VERBOSE_HELP",
-    "_build_section_summary",
-    "_cli",
-    "_display",
-    "_display_cli_path",
-    "_entry_point",
-    "_passage_payload",
-    "_print_json_envelope",
-    "_select_section_opening_line",
-    "main",
-]
+__all__ = ["Catalog", "_cli", "_entry_point", "main"]
 
 # ---------------------------------------------------------------------------
 # CLI epilog

--- a/gutenbit/cli/_context.py
+++ b/gutenbit/cli/_context.py
@@ -158,7 +158,7 @@ def _catalog_status_message(fetch_info: CatalogFetchInfo | None, *, refresh: boo
 
 
 # ---------------------------------------------------------------------------
-# Catalog and text normalization
+# Catalog loading
 # ---------------------------------------------------------------------------
 
 
@@ -175,11 +175,6 @@ def _load_catalog(refresh: bool = False, *, display: CliDisplay, as_json: bool) 
             )
         )
     return catalog
-
-
-def _normalize_apostrophes(s: str) -> str:
-    """Replace curly/typographic apostrophes with ASCII for matching."""
-    return s.replace("\u2019", "'").replace("\u2018", "'")
 
 
 # ---------------------------------------------------------------------------

--- a/gutenbit/cli/_sections.py
+++ b/gutenbit/cli/_sections.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from gutenbit.cli._context import _display, _load_catalog, _normalize_apostrophes
+from gutenbit.cli._context import _display, _load_catalog
 from gutenbit.cli._display import CliDisplay
 from gutenbit.cli._json import JSON_OPENING_LINE_PREVIEW_CHARS
 from gutenbit.cli._query import (
@@ -18,6 +18,7 @@ from gutenbit.cli._query import (
     _section_path_parts,
 )
 from gutenbit.cli._text_utils import (
+    _normalize_apostrophes,
     _preview,
     _select_section_opening_line,
     _single_line,
@@ -80,29 +81,6 @@ def _canonical_section_match(
         if div_parts_match(query_parts, _section_selector_parts(section_path)):
             return section_path, int(section["section_number"])
     return None
-
-
-def _truncate_section_label(label: str, width: int) -> str:
-    """Truncate a section path, preferring the most specific (deepest) level.
-
-    When the full path ("BOOK TITLE / CHAPTER 1") exceeds *width*,
-    show the deepest level with a ".../ " prefix so users see the
-    chapter name rather than a truncated book title.
-    """
-    if len(label) <= width:
-        return label
-    parts = label.split(" / ")
-    if len(parts) > 1:
-        deepest = parts[-1]
-        prefix = ".../ "
-        if len(prefix) + len(deepest) <= width:
-            return prefix + deepest
-        # Deepest level itself is too long — truncate it with prefix
-        keep = max(1, width - len(prefix) - 3)
-        return prefix + deepest[:keep] + "..."
-    # Single level, just truncate
-    keep = max(1, width - 3)
-    return label[:keep] + "..."
 
 
 def _section_examples(db: Database, book_id: int, *, limit: int = 5) -> list[str]:

--- a/gutenbit/cli/_text_utils.py
+++ b/gutenbit/cli/_text_utils.py
@@ -35,6 +35,11 @@ def _summarize_semicolon_list(raw: str, *, max_items: int) -> str:
     return f"{shown}; +{len(items) - max_items} more"
 
 
+def _normalize_apostrophes(s: str) -> str:
+    """Replace curly/typographic apostrophes with ASCII for matching."""
+    return s.replace("\u2019", "'").replace("\u2018", "'")
+
+
 def _indent_block(text: str, prefix: str = "    ") -> str:
     lines = text.splitlines()
     if not lines:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,8 +10,8 @@ from pathlib import Path
 import pytest
 
 from gutenbit.catalog import BookRecord
-from gutenbit.cli import _display_cli_path
 from gutenbit.cli import main as cli_main
+from gutenbit.cli._context import _display_cli_path
 from gutenbit.db import Database
 from gutenbit.html_chunker import chunk_html
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,7 +1,8 @@
 from copy import deepcopy
 from io import StringIO
 
-from gutenbit.cli import _build_section_summary, _passage_payload
+from gutenbit.cli._json import _passage_payload
+from gutenbit.cli._sections import _build_section_summary
 from gutenbit.cli._display import (
     CliDisplay,
     _footer_title,

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -20,8 +20,8 @@ from gutenbit.catalog import (
     CatalogFetchInfo,
     apply_catalog_policy,
 )
-from gutenbit.cli import _select_section_opening_line
 from gutenbit.cli import main as cli_main
+from gutenbit.cli._text_utils import _select_section_opening_line
 from gutenbit.db import Database, SearchResult, TextState
 from gutenbit.html_chunker import CHUNKER_VERSION, Chunk, chunk_html
 


### PR DESCRIPTION
## Summary
- Remove 5 unnecessary re-exports from `cli/__init__.py` — tests now import directly from the submodule that owns each symbol (`_context`, `_json`, `_sections`, `_text_utils`), making the dependency graph explicit. Kept `Catalog` re-export only because ~15 tests monkeypatch `gutenbit.cli.Catalog.fetch`.
- Move `_normalize_apostrophes` from `_context.py` to `_text_utils.py` where it belongs alongside the other pure text utilities.
- Remove dead `_truncate_section_label` from `_sections.py` (never called anywhere).

Net: -47 lines across 7 files.

## Test plan
- [x] All 330 unit tests pass
- [x] All 35 network tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)