### PR TITLE
Allow view --section --forward to cross sections and enrich footer (KEI-100)

### DIFF
--- a/gutenbit/cli/_commands.py
+++ b/gutenbit/cli/_commands.py
@@ -1616,7 +1616,8 @@ def _cmd_view(
             else:
                 forward = _effective_forward(DEFAULT_VIEW_FORWARD)
                 all_scope = None
-                rows = _section_reading_window(rows, text_passages=forward)
+                all_rows = [row for row in db_conn.chunk_records(book) if row.position >= anchor.position]
+                rows = _section_reading_window(all_rows, text_passages=forward)
             record = _view_payload(
                 section=resolved_section,
                 section_number=section_number,

--- a/gutenbit/cli/_display.py
+++ b/gutenbit/cli/_display.py
@@ -224,7 +224,17 @@ def _passage_footer_stats(
         _footer_book_id(payload[BOOK_ID_KEY]),
     ]
     if payload.get("section"):
-        stats.append(f"section {_section_label(payload['section'])}")
+        stats.append(
+            f"section {_truncate_single_line(_section_label(payload['section']), FOOTER_TITLE_MAX_CHARS)}"
+        )
+    if payload.get("section_number") is not None:
+        stats.append(f"section no. {payload['section_number']}")
+    if payload.get("position") is not None:
+        stats.append(f"position {payload['position']}")
+    if payload.get("forward") is not None:
+        stats.append(f"forward {payload['forward']}")
+    if payload.get("radius") is not None:
+        stats.append(f"radius {payload['radius']}")
     stats.extend(item for item in (footer_stats or []) if item)
     return stats
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -146,7 +146,7 @@ def test_rich_passage_separates_title_from_metadata(tmp_path):
     )
     out = StringIO()
 
-    CliDisplay(stdout=out, interactive=True, color=False, width=100).passage(
+    CliDisplay(stdout=out, interactive=True, color=False, width=120).passage(
         payload,
         action_hints={
             "toc": "gutenbit toc 1",
@@ -164,7 +164,10 @@ def test_rich_passage_separates_title_from_metadata(tmp_path):
     assert "Book ID 1 · Section CHAPTER 1 · Section No. 1 · Position 0 · Forward 3" in rendered
     assert " · No. 1 · " not in rendered
     assert "Forward 3\n\nCHAPTER 1" in rendered
-    assert "Moby Dick · id 1 · section CHAPTER 1 · 1 paragraph · 3 words · 1m read" in rendered
+    assert (
+        "Moby Dick · id 1 · section CHAPTER 1 · section no. 1 · position 0 · forward 3"
+        " · 1 paragraph · 3 words · 1m read" in rendered
+    )
     assert "\nNext\n" in rendered
     assert "gutenbit toc 1" in rendered
     assert 'gutenbit search "Ishmael" --book 1' in rendered
@@ -191,7 +194,10 @@ def test_plain_passage_shows_footer_stats(tmp_path):
     )
 
     rendered = out.getvalue()
-    assert "Moby Dick · id 1 · section CHAPTER 1 · 0 paragraphs · - words · - read" in rendered
+    assert (
+        "Moby Dick · id 1 · section CHAPTER 1 · section no. 1 · position 0 · forward 1"
+        " · 0 paragraphs · - words · - read" in rendered
+    )
 
 
 def test_rich_section_summary_uses_simple_section_layout(tmp_path):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1534,7 +1534,10 @@ def test_view_position_heading_only_shows_dash_footer_stats(tmp_path):
     code, out, _err = _run_cli(db_path, "view", "1", "--position", "0", "--forward", "1")
     assert code == 0
     assert "CHAPTER 1" in out
-    assert "Moby Dick · id 1 · section CHAPTER 1 · 0 paragraphs · - words · - read" in out
+    assert (
+        "Moby Dick · id 1 · section CHAPTER 1 · section no. 1 · position 0 · forward 1"
+        " · 0 paragraphs · - words · - read" in out
+    )
 
 
 def test_view_position_with_radius_header(tmp_path):
@@ -1601,6 +1604,21 @@ def test_view_section_with_forward_header(tmp_path):
     assert "position=0  forward=1" in out
     assert "CHAPTER 1" in out
     assert "Call me Ishmael" in out
+
+
+def test_view_section_forward_extends_into_next_section(tmp_path):
+    db = _make_db(tmp_path)
+    db_path = db.path
+    db.close()
+
+    # CHAPTER 1 has 2 text chunks; forward=3 should extend into CHAPTER 2
+    code, out, _err = _run_cli(
+        db_path, "view", "1", "--section", "CHAPTER 1", "--forward", "3"
+    )
+    assert code == 0
+    assert "Call me Ishmael" in out  # CHAPTER 1 text
+    assert "It is a way I have" in out  # CHAPTER 1 text
+    assert "I stuffed a shirt" in out  # CHAPTER 2 text (crossed boundary)
 
 
 def test_view_section_miss_shows_examples(tmp_path):


### PR DESCRIPTION
## Summary
- `view --section SECTION --forward N` now extends into subsequent sections when N exceeds the current section's text chunks, instead of truncating at the section boundary
- View footer now includes section no., position, and forward/radius navigational fields with lowercase labels
- Long section labels in the footer are truncated at 32 characters (matching the existing title truncation)

## Test plan
- [x] Existing view/footer tests updated and passing
- [x] New `test_view_section_forward_extends_into_next_section` verifies cross-section forward behavior
- [x] Full test suite: 174 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)