### PR TITLE
Recognize INDUCTION as a broad dramatic keyword (KEI-99)

### DIFF
--- a/gutenbit/html_chunker/__init__.py
+++ b/gutenbit/html_chunker/__init__.py
@@ -40,7 +40,7 @@ from gutenbit.html_chunker._sections import (
 # ---------------------------------------------------------------------------
 
 HTML_PARSER_BACKEND = "lxml"
-CHUNKER_VERSION = 28
+CHUNKER_VERSION = 29
 
 
 @dataclass(frozen=True, slots=True)

--- a/gutenbit/html_chunker/_common.py
+++ b/gutenbit/html_chunker/_common.py
@@ -11,13 +11,14 @@ from bs4 import NavigableString, Tag
 # Constants and frozen sets
 # ---------------------------------------------------------------------------
 
-_BROAD_KEYWORDS = frozenset({"book", "part", "act", "epilogue", "volume"})
+_BROAD_KEYWORDS = frozenset({"book", "part", "act", "epilogue", "induction", "volume"})
 _BROAD_NESTING_DEPTHS = {
     "volume": 1,
     "part": 2,
     "epilogue": 2,
     "book": 3,
     "act": 3,
+    "induction": 3,
 }
 
 _FRONT_MATTER_HEADINGS = frozenset(
@@ -45,7 +46,7 @@ _BARE_HEADING_NUMBER_RE = re.compile(
 )
 
 _HEADING_KEYWORD_RE = re.compile(
-    r"^(?:BOOK|PART|ACT|ACTUS|EPILOGUE|VOLUME|CHAPTER|STAVE|SCENE|SCENA|SCOENA|SECTION|ADVENTURE)\.?\s",
+    r"^(?:(?:BOOK|PART|ACT|ACTUS|EPILOGUE|VOLUME|CHAPTER|STAVE|SCENE|SCENA|SCOENA|SECTION|ADVENTURE)\.?\s|INDUCTION\b)",
     re.IGNORECASE,
 )
 _START_DELIMITER_RE = re.compile(
@@ -78,7 +79,7 @@ _NON_ALNUM_RE = re.compile(r"[^A-Za-z0-9]+")
 
 # Keywords that are almost exclusively structural even without a trailing number.
 _STANDALONE_STRUCTURAL_RE = re.compile(
-    r"\bEPILOGUE\b|\bPROLOGUE\b|\bAPPENDIX\b",
+    r"\bEPILOGUE\b|\bPROLOGUE\b|\bAPPENDIX\b|\bINDUCTION\b",
     re.IGNORECASE,
 )
 _FALLBACK_START_HEADING_RE = re.compile(

--- a/tests/test_battle.py
+++ b/tests/test_battle.py
@@ -77,6 +77,25 @@ def test_shakespeare_anthology_nests_acts_and_scenes_under_work_titles():
     assert sonnets.div2 == ""
 
 
+def test_shakespeare_anthology_nests_induction_under_parent_play():
+    headings = _headings(100)
+
+    henry_iv_induction = next(
+        heading
+        for heading in headings
+        if heading.content == "INDUCTION"
+        and heading.div1 == "THE SECOND PART OF KING HENRY THE FOURTH"
+    )
+    assert henry_iv_induction.div2 == "INDUCTION"
+
+    taming_induction = next(
+        heading
+        for heading in headings
+        if heading.content == "INDUCTION" and heading.div1 == "THE TAMING OF THE SHREW"
+    )
+    assert taming_induction.div2 == "INDUCTION"
+
+
 def test_locke_essay_volume_two_skips_contents_scaffolding():
     headings = _headings(10616)
     heading_texts = {heading.content for heading in headings}


### PR DESCRIPTION
## Summary

- **Parser bug**: "INDUCTION" sections in PG 100 (Complete Works of Shakespeare) appeared as top-level sections instead of nesting under their parent plays (Henry IV Part 2, Taming of the Shrew).
- **Root cause**: The parser didn't recognize "INDUCTION" as a structural keyword, so `_normalize_collection_titles` promoted it to work-title level.
- **Fix**: Register INDUCTION as a broad dramatic keyword (same level as ACT) in `_HEADING_KEYWORD_RE`, `_BROAD_KEYWORDS`, `_BROAD_NESTING_DEPTHS`, and `_STANDALONE_STRUCTURAL_RE`. This is a general structural rule — any Gutenberg play with an Induction section will now parse correctly.
- **Regression test**: `test_shakespeare_anthology_nests_induction_under_parent_play` asserts both INDUCTION sections in PG 100 nest under their parent works.

## Test plan

- [x] `uv run pytest` — 341 passed
- [x] `uv run pytest -m network` — 36 passed (full battle corpus)
- [x] Verified `toc`, `view`, and `search` CLI output for PG 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)