### PR TITLE
Fix Theologico-Political Treatise chapter parsing

### DIFF
--- a/gutenbit/html_chunker/_headings.py
+++ b/gutenbit/html_chunker/_headings.py
@@ -307,6 +307,10 @@ def _is_fallback_start_heading_text(heading_text: str) -> bool:
 
 def _is_dialogue_speaker_heading(heading_text: str) -> bool:
     """Return True for uppercase speaker attributions like ``SOCRATES - GLAUCON``."""
+    if _heading_keyword(heading_text):
+        return False
+    if _STANDALONE_STRUCTURAL_RE.search(heading_text):
+        return False
     if " - " not in heading_text:
         return False
 

--- a/gutenbit/html_chunker/_scanning.py
+++ b/gutenbit/html_chunker/_scanning.py
@@ -10,8 +10,10 @@ from bs4 import BeautifulSoup, NavigableString, Tag
 from gutenbit.html_chunker._common import (
     _END_DELIMITER_RE,
     _FRONT_MATTER_HEADINGS,
+    _HEADING_KEYWORD_RE,
     _HEADING_TAG_SET,
     _NON_ALNUM_RE,
+    _STANDALONE_STRUCTURAL_RE,
     _START_DELIMITER_RE,
     _clean_heading_text,
     _collect_text_parts,
@@ -165,17 +167,18 @@ def _scan_document(soup: BeautifulSoup) -> _DocumentIndex:
             for child in node.contents:
                 if isinstance(child, Tag):
                     tag_children.append(child)
-                elif isinstance(child, NavigableString):
-                    if start_marker_parent is None or end_marker_parent is None:
-                        text = str(child)
-                        if start_marker_parent is None and _START_DELIMITER_RE.search(text):
-                            p = child.parent
-                            if isinstance(p, Tag):
-                                start_marker_parent = p
-                        if end_marker_parent is None and _END_DELIMITER_RE.search(text):
-                            p = child.parent
-                            if isinstance(p, Tag):
-                                end_marker_parent = p
+                elif isinstance(child, NavigableString) and (
+                    start_marker_parent is None or end_marker_parent is None
+                ):
+                    text = str(child)
+                    if start_marker_parent is None and _START_DELIMITER_RE.search(text):
+                        p = child.parent
+                        if isinstance(p, Tag):
+                            start_marker_parent = p
+                    if end_marker_parent is None and _END_DELIMITER_RE.search(text):
+                        p = child.parent
+                        if isinstance(p, Tag):
+                            end_marker_parent = p
             for child in reversed(tag_children):
                 stack.append((child, False))
             continue
@@ -374,7 +377,41 @@ def _is_toc_paragraph(paragraph: Tag, *, has_pginternal: bool | None = None) -> 
     # Check if removing pginternal link text leaves only punctuation/whitespace,
     # without re-parsing the paragraph.
     residue = _container_residue_without_link_text(paragraph)
-    return _NON_ALNUM_RE.sub("", residue) == ""
+    return _NON_ALNUM_RE.sub("", residue) == "" or _is_single_link_structural_toc_paragraph(
+        paragraph, links=links, residue=residue
+    )
+
+
+def _is_single_link_structural_toc_paragraph(
+    paragraph: Tag,
+    *,
+    links: list[Tag] | None = None,
+    residue: str | None = None,
+) -> bool:
+    """Return True for single-link TOC entries whose subtitle sits outside the anchor."""
+    if links is None:
+        links = paragraph.find_all("a", class_="pginternal")
+    if len(links) != 1:
+        return False
+
+    link_text = _clean_heading_text(" ".join(links[0].get_text(" ", strip=True).split()))
+    if not link_text:
+        return False
+    if not (_HEADING_KEYWORD_RE.match(link_text) or _STANDALONE_STRUCTURAL_RE.search(link_text)):
+        return False
+
+    if residue is None:
+        residue = _container_residue_without_link_text(paragraph)
+    stripped_residue = residue.lstrip()
+    if not stripped_residue.startswith(("-", "—", ":")):
+        return False
+
+    subtitle = _clean_heading_text(stripped_residue.lstrip("-—:;,. "))
+    if not subtitle or _NON_ALNUM_RE.sub("", subtitle) == "":
+        return False
+    if _HEADING_KEYWORD_RE.match(subtitle):
+        return False
+    return _STANDALONE_STRUCTURAL_RE.search(subtitle) is None
 
 
 def _is_dense_chapter_index_paragraph(paragraph: Tag) -> bool:

--- a/gutenbit/html_chunker/_sections.py
+++ b/gutenbit/html_chunker/_sections.py
@@ -81,7 +81,8 @@ _TAIL_BOUNDARY_HEADING_RE = re.compile(
     re.IGNORECASE,
 )
 _TAIL_SECTION_HEADING_RE = re.compile(
-    r"^(?:note\b|note to\b|letter\b|a letter from\b|finale\b|the conclusion\b)",
+    r"^(?:note\b|note to\b|letter\b|a letter from\b|finale\b|the conclusion\b|"
+    r"author'?s?\s+endnotes?\b)",
     re.IGNORECASE,
 )
 
@@ -570,7 +571,9 @@ def _find_non_structural_boundary_after(
     if anchor_pos is None:
         return None
 
-    lo = bisect_right(doc_index.heading_positions, anchor_pos)  # first heading strictly after anchor_pos
+    lo = bisect_right(
+        doc_index.heading_positions, anchor_pos
+    )  # first heading strictly after anchor_pos
     for ih in doc_index.headings[lo:]:
         if not doc_index.bounds.contains(ih.position):
             continue
@@ -968,4 +971,3 @@ def _should_scan_paragraph_heading_rows(
         if non_toc_scanned >= 400:
             break
     return False
-

--- a/gutenbit/html_chunker/_toc.py
+++ b/gutenbit/html_chunker/_toc.py
@@ -76,15 +76,15 @@ def _previous_heading_text(link: Tag, *, doc_index: _DocumentIndex) -> str:
     """
     link_pos = doc_index.tag_positions.get(id(link))
     if link_pos is not None and doc_index.heading_positions:
-        idx = bisect_left(doc_index.heading_positions, link_pos) - 1  # last heading strictly before link_pos
+        idx = (
+            bisect_left(doc_index.heading_positions, link_pos) - 1
+        )  # last heading strictly before link_pos
         if idx >= 0:
             return doc_index.headings[idx].text
     return ""
 
 
-def _is_structural_toc_link(
-    link: Tag, link_text: str, *, doc_index: _DocumentIndex
-) -> bool:
+def _is_structural_toc_link(link: Tag, link_text: str, *, doc_index: _DocumentIndex) -> bool:
     """Return True for TOC links that can map to actual section headings."""
     if not _is_toc_context_link(link):
         return False

--- a/tests/test_battle.py
+++ b/tests/test_battle.py
@@ -237,6 +237,48 @@ def test_republic_preserves_book_headings_over_dialogue_speakers():
     assert all(heading.div2 == "" for heading in headings)
 
 
+def test_theologico_political_treatise_keeps_chapter_sequences_across_parts():
+    part_one = _headings(989)
+    part_two = _headings(990)
+    part_three = _headings(991)
+
+    def chapter_markers(headings: list[Chunk]) -> list[str]:
+        markers: list[str] = []
+        for heading in headings:
+            match = re.match(r"^CHAPTER\s+[IVXLCDM]+", heading.content)
+            if match:
+                markers.append(match.group(0))
+        return markers
+
+    assert part_one[0].content == "PREFACE."
+    assert chapter_markers(part_one) == [
+        "CHAPTER I",
+        "CHAPTER II",
+        "CHAPTER III",
+        "CHAPTER IV",
+        "CHAPTER V",
+    ]
+    assert part_one[-1].content == "AUTHOR'S ENDNOTES TO THE THEOLOGICO-POLITICAL TREATISE"
+
+    assert chapter_markers(part_two) == [
+        "CHAPTER VI",
+        "CHAPTER VII",
+        "CHAPTER VIII",
+        "CHAPTER IX",
+        "CHAPTER X",
+    ]
+    assert part_two[-1].content == "AUTHOR'S ENDNOTES TO THE THEOLOGICO-POLITICAL TREATISE"
+
+    assert chapter_markers(part_three) == [
+        "CHAPTER XI",
+        "CHAPTER XII",
+        "CHAPTER XIII",
+        "CHAPTER XIV",
+        "CHAPTER XV",
+    ]
+    assert part_three[-1].content == "AUTHOR'S ENDNOTES TO THE THEOLOGICO-POLITICAL TREATISE"
+
+
 def test_faust_keeps_only_top_level_dramatic_sections():
     headings = _headings(3023)
     heading_texts = [heading.content for heading in headings]

--- a/tests/test_html_chunker.py
+++ b/tests/test_html_chunker.py
@@ -755,6 +755,34 @@ def test_inline_pginternal_links_not_toc():
     assert paragraphs == ["Body text with inline reference [1] remains content."]
 
 
+def test_single_link_chapter_toc_paragraph_with_subtitle_is_toc():
+    html = _make_html("""
+    <p><a href="#ch11" class="pginternal">CHAPTER XI</a> - Of Prophecy.</p>
+    <p><a href="#ch12" class="pginternal">CHAPTER XII</a> - Of Miracles.</p>
+    <p><a href="#endnotes" class="pginternal">Author's Endnotes to the Treatise.</a></p>
+    <h2><a id="ch11"></a>CHAPTER XI - Of Prophecy.</h2>
+    <p>Chapter eleven paragraph.</p>
+    <h2><a id="ch12"></a>CHAPTER XII - Of Miracles.</h2>
+    <p>Chapter twelve paragraph.</p>
+    <h2><a id="endnotes"></a>Author's Endnotes to the Treatise.</h2>
+    <p>Endnotes paragraph.</p>
+    """)
+    chunks = chunk_html(html)
+    headings = [c.content for c in chunks if c.kind == "heading"]
+    paragraphs = [c.content for c in chunks if c.kind == "text"]
+
+    assert headings == [
+        "CHAPTER XI - Of Prophecy.",
+        "CHAPTER XII - Of Miracles.",
+        "Author's Endnotes to the Treatise.",
+    ]
+    assert paragraphs == [
+        "Chapter eleven paragraph.",
+        "Chapter twelve paragraph.",
+        "Endnotes paragraph.",
+    ]
+
+
 # ------------------------------------------------------------------
 # Heading text extraction
 # ------------------------------------------------------------------
@@ -1552,6 +1580,23 @@ def test_dialogue_speaker_headings_do_not_replace_book_structure():
     assert paragraphs[2].div2 == ""
 
 
+def test_heading_scan_keeps_hyphenated_chapter_headings():
+    html = _make_html("""
+    <h1>A Theologico-Political Treatise</h1>
+    <h3>CHAPTER VI. - OF MIRACLES.</h3>
+    <p>Chapter six paragraph.</p>
+    <h3>CHAPTER VII. - OF THE INTERPRETATION OF SCRIPTURE.</h3>
+    <p>Chapter seven paragraph.</p>
+    """)
+    chunks = chunk_html(html)
+    headings = [c.content for c in chunks if c.kind == "heading"]
+
+    assert headings == [
+        "CHAPTER VI. - OF MIRACLES.",
+        "CHAPTER VII. - OF THE INTERPRETATION OF SCRIPTURE.",
+    ]
+
+
 def test_heading_scan_starts_from_prologues_and_skips_short_dramatic_cues():
     html = _make_html("""
     <h5>INTRODUCTORY NOTE</h5>
@@ -1696,6 +1741,32 @@ def test_toc_refinement_keeps_terminal_note_after_last_chapter():
 
     assert headings == ["CHAPTER I", "CHAPTER II", "NOTE"]
     assert note_paragraph.div1 == "NOTE"
+
+
+def test_toc_refinement_keeps_terminal_authors_endnotes_after_same_rank_chapters():
+    html = _make_html("""
+    <p><a href="#ch1" class="pginternal">CHAPTER I</a> - Of Prophecy.</p>
+    <p><a href="#ch2" class="pginternal">CHAPTER II</a> - Of Miracles.</p>
+    <p><a href="#endnotes" class="pginternal">Author's Endnotes to the Treatise.</a></p>
+    <h3><a id="ch1"></a>CHAPTER I - Of Prophecy.</h3>
+    <p>Chapter one paragraph.</p>
+    <h3><a id="ch2"></a>CHAPTER II - Of Miracles.</h3>
+    <p>Chapter two paragraph.</p>
+    <h3><a id="endnotes"></a>Author's Endnotes to the Treatise.</h3>
+    <p>Endnotes paragraph.</p>
+    """)
+    chunks = chunk_html(html)
+    headings = [c.content for c in chunks if c.kind == "heading"]
+    endnotes_paragraph = next(
+        c for c in chunks if c.kind == "text" and c.content == "Endnotes paragraph."
+    )
+
+    assert headings == [
+        "CHAPTER I - Of Prophecy.",
+        "CHAPTER II - Of Miracles.",
+        "Author's Endnotes to the Treatise.",
+    ]
+    assert endnotes_paragraph.div1 == "Author's Endnotes to the Treatise."
 
 
 def test_toc_refinement_keeps_leading_preface_before_first_toc_section():


### PR DESCRIPTION
## Summary
- stop classifying hyphenated structural chapter headings as dialogue-speaker headings
- recognize single-link TOC paragraphs where the chapter subtitle sits outside the anchor
- preserve trailing author endnotes after same-rank chapter runs and lock the behavior with fixture and live regressions

## Verification
- uv run pytest
- uv run pytest -m network
- uv run gutenbit --db /tmp/kei102-cli.db add 989 990 991
- uv run gutenbit --db /tmp/kei102-cli.db toc 989
- uv run gutenbit --db /tmp/kei102-cli.db toc 990
- uv run gutenbit --db /tmp/kei102-cli.db toc 991
- uv run gutenbit --db /tmp/kei102-cli.db search superstition --book 989
- uv run gutenbit --db /tmp/kei102-cli.db search miracles --book 990
- uv run gutenbit --db /tmp/kei102-cli.db search apostles --book 991
- uv run gutenbit --db /tmp/kei102-cli.db view 989
- uv run gutenbit --db /tmp/kei102-cli.db view 990
- uv run gutenbit --db /tmp/kei102-cli.db view 991

Linear: KEI-102