### PR TITLE
Add Claude Code skills

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: changelog
+description: >
+  Generate or update a project changelog following the Keep a Changelog standard
+  (keepachangelog.com) and Semantic Versioning (semver.org). Use this skill whenever the user
+  asks to "create the changelog", "update the changelog", "generate release notes", "write the
+  CHANGELOG.md", or "add a new changelog entry". Also trigger for requests like "what changed
+  in this release", "draft the v1.x changelog", or "document what's new since the last version".
+---
+
+# Changelog
+
+This skill produces a `CHANGELOG.md` that follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+standard with [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The core principle: the changelog is for humans, not git diffs. Every entry should describe
+what changed from a user's perspective, not the implementation detail.
+
+## Step 1 — Understand the scope
+
+Clarify with the user (or infer from context):
+- Are we creating a fresh `CHANGELOG.md`, or appending a new release entry to an existing one?
+- What version are we documenting? (Check `git tag --sort=-version:refname | head -5` and the
+  current version in `pyproject.toml`, `package.json`, or the project's version command)
+- What's the date range? (Since the last tag, since a specific commit, or all time?)
+
+## Step 2 — Gather changes
+
+Run these in the project root to collect raw material:
+
+```bash
+# Get recent commits since last tag
+git log $(git describe --tags --abbrev=0)..HEAD --oneline --no-merges
+
+# Or all commits if starting fresh
+git log --oneline --no-merges | head -100
+
+# See what tags exist
+git tag --sort=-version:refname | head -10
+```
+
+Also check issue trackers (Linear, GitHub Issues, Jira, etc.) for recently closed issues —
+they often contain the clearest description of what changed from the user's perspective.
+
+## Step 3 — Categorize changes
+
+Map each commit or issue into one of these Keep a Changelog sections. Use your judgment — the
+categories are about user impact, not code location:
+
+| Section | When to use |
+|---|---|
+| **Added** | New features, new commands, new flags, new behaviors the user can now do |
+| **Changed** | Changes to existing behavior, renames, updated defaults, UX improvements |
+| **Deprecated** | Features that still work but will be removed in a future release |
+| **Removed** | Features, flags, or commands that no longer exist |
+| **Fixed** | Bug fixes — things that were broken and now work correctly |
+| **Security** | Security patches, vulnerability fixes, compliance changes |
+
+Entries within each section should be written as concise imperative sentences from the user's
+perspective: "Add `--output` flag to `export` command" not "Implemented OutputFormat parameter
+in ExportHandler".
+
+Skip purely internal changes (refactors with no user-facing effect, CI tweaks, test
+infrastructure) unless they affect performance in a measurable way.
+
+## Step 4 — Determine the version number
+
+Use semantic versioning rules:
+- **Patch** (x.x.N): Only bug fixes, no new features, no breaking changes
+- **Minor** (x.N.0): New features added in a backward-compatible way
+- **Major** (N.0.0): Breaking changes (removed commands, changed flag behavior, etc.)
+
+Check the last release version: `git describe --tags --abbrev=0`
+
+## Step 5 — Write the changelog entry
+
+Use this exact format:
+
+```markdown
+## [<version>] - <YYYY-MM-DD>
+
+### Added
+- <entry>
+- <entry>
+
+### Changed
+- <entry>
+
+### Fixed
+- <entry>
+```
+
+Only include sections that have entries — omit empty ones.
+
+For a fresh `CHANGELOG.md`, add the header:
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [<version>] - <YYYY-MM-DD>
+...
+```
+
+The `[Unreleased]` section at the top accumulates changes since the latest release. Leave it
+empty if there's nothing yet.
+
+## Step 6 — Write the file
+
+Write or update `CHANGELOG.md` at the project root. If updating, insert the new entry
+immediately after the `## [Unreleased]` section (or at the top if there's no Unreleased block).
+
+Preserve all existing entries exactly — only add, never rewrite history.
+
+## Output checklist
+
+- [ ] Version number follows semver
+- [ ] Date is accurate (today's date for a new release, or the tag date for historical)
+- [ ] Each entry is written from the user's perspective
+- [ ] No internal implementation details in user-facing entries
+- [ ] Empty sections are omitted
+- [ ] `[Unreleased]` section is present at the top
+- [ ] Links to PRs or issues are included where useful (optional but helpful)

--- a/.claude/skills/cli-api-review/SKILL.md
+++ b/.claude/skills/cli-api-review/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: cli-api-review
+description: >
+  Review Gutenbit CLI commands for consistency, ergonomics, and alignment with the project's
+  established design patterns. Use this skill whenever the user asks to "review the CLI API",
+  "check cli consistency", "audit the command design", "review cli ergonomics", or when filing
+  or working on a Linear issue prefixed with "cli api:" or "cli ergonomics:". Also trigger for
+  requests like "is the cli consistent?", "what cli issues should we fix?", "review the help
+  text", or "check our verb choices across commands".
+---
+
+# CLI API Review
+
+This skill audits the Gutenbit CLI for internal consistency, ergonomic clarity, and alignment
+with the design patterns the project has established over time. The goal is a CLI that feels
+like one coherent tool — where a user who knows one command can correctly guess how the others
+behave.
+
+## Step 1 — Capture the current CLI surface
+
+Run these from the project root:
+
+```bash
+uv run gutenbit --help
+uv run gutenbit add --help
+uv run gutenbit toc --help
+uv run gutenbit view --help
+uv run gutenbit search --help
+uv run gutenbit books --help
+# Add any other subcommands that appear in --help output
+```
+
+Save the full output. This is your source of truth.
+
+## Step 2 — Check verb and flag consistency
+
+Gutenbit's established conventions (as of the current codebase):
+
+| Pattern | Correct | Avoid |
+|---|---|---|
+| Reprocessing/updating | `--update` | `--refresh`, `--reprocess`, `--reload` |
+| Showing all results | `--all` | `--full`, `--complete`, `--everything` |
+| Filtering by book | `--book <id>` | `--book-id`, `--id`, `-b` (without long form) |
+| Section reference | `--section <N>` | `--chapter`, `--part`, `--chunk` |
+
+Check every flag across every subcommand for these patterns. Flag any deviations. If a new
+convention seems like an improvement over the established one, note it explicitly as a
+"proposed convention change" rather than a plain inconsistency — that distinction matters.
+
+## Step 3 — Check auto-behavior conventions
+
+A key ergonomic principle in Gutenbit: commands should "do the right thing" rather than make
+the user jump through hoops. Known patterns:
+
+- **Auto-add**: If a user runs `toc <id>` for a book not in the DB, the command should add it
+  automatically rather than prompt. The user asking for a TOC implies they want the book.
+- **ID remapping**: If a user passes a non-canonical PG ID that resolves to a different
+  canonical ID, commands should follow the remap silently and succeed.
+- **Multi-ID input**: Where it makes sense (e.g., `search`), commands should accept multiple
+  `--book` IDs at once.
+
+Check each command: does it apply these principles? Where it doesn't, note whether the gap is
+a bug, a missing feature, or a deliberate design choice.
+
+## Step 4 — Review help text quality
+
+Good help text is the entry portal for new users. Check:
+
+- **Description lines**: Clear, concise, jargon-free? Does the top-level `--help` describe
+  what Gutenbit does in a way that a newcomer immediately understands?
+- **Option descriptions**: Do they say what the option *does*, not just what it *is*?
+  (e.g., "reprocess stored books" not "update flag")
+- **Formatting artifacts**: Any `{curly_braces}`, raw variable names, or unparsed template
+  strings showing through?
+- **Consistent capitalization and punctuation** across all help strings?
+- **Output labels**: Are search/view results labeled clearly? (e.g., "Section No. 181" vs
+  bare "No. 181")
+
+## Step 5 — Write the review report
+
+Structure your findings like this:
+
+```
+## CLI API Review — <date>
+
+### Summary
+<2–3 sentence overview of overall consistency and top concerns>
+
+### Inconsistencies Found
+For each issue:
+- **[COMMAND] [FLAG/BEHAVIOR]**: Description of the inconsistency
+  - Current behavior: ...
+  - Expected (per convention): ...
+  - Suggested fix: ...
+  - Severity: low / medium / high
+
+### Auto-Behavior Gaps
+<Same format as above>
+
+### Help Text Issues
+<Same format>
+
+### Proposed Convention Changes
+<List any places where the existing convention itself seems worth revisiting, with rationale>
+
+### Recommended Linear Issues
+<For each finding that warrants a ticket, suggest a title following the "cli api: ..." or
+"cli ergonomics: ..." naming pattern the project uses>
+```
+
+If this review was triggered in the context of an existing Linear issue, post the report as
+a comment and link any newly created follow-up issues.

--- a/.claude/skills/discover-battle-tests/SKILL.md
+++ b/.claude/skills/discover-battle-tests/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: discover-battle-tests
+description: >
+  Discover new Project Gutenberg works and create templated Linear battle-test sub-issues.
+  Use when the user asks to "discover N new battle tests", "find new battle test candidates",
+  "create battle test issues", "add more battle tests to Linear", or any variation of
+  "discover/find/create N battle test issues". The user specifies how many to discover
+  (default 10). This skill handles discovery and issue creation only — it does not run the
+  battle tests themselves.
+argument-hint: "[count]"
+---
+
+# Discover Battle Tests
+
+Create exactly `$ARGUMENTS` (default: 10) new child issues for live CLI/parsing battle tests
+under a single parent issue in Linear. This skill is discovery and issue-creation only — do
+not run the battle tests.
+
+## Goal
+
+Identify `$ARGUMENTS` **new**, previously unseen Project Gutenberg works in English,
+prioritizing canonical and widely known literature, and file them as templated child issues
+in Linear.
+
+## Step 1 — Build the exclusion set
+
+Before selecting candidates, gather every PG ID and work already covered. A work is "seen"
+if it appears in **any** of these sources:
+
+1. **Linear**: Search for issues whose title starts with
+   `Gutenbit cli and parsing battle test:`. Collect every PG ID and work title from the
+   results. Use `list_issues` with query `Gutenbit cli and parsing battle test` in the
+   `Gutenbit` project.
+
+2. **Test files**: Read `tests/test_battle.py` and any other test files under `tests/` that
+   reference PG IDs. Extract every PG ID.
+
+3. **Corpus reference**: Read
+   `.claude/skills/gutenbit-live-battle-test/references/kei-17-corpus.md` and extract every
+   PG ID listed in the failure-class table.
+
+Merge all three sources into a single deduplicated exclusion set of PG IDs and work titles.
+
+## Step 2 — Build a candidate list
+
+Generate a candidate list of at least 2× the requested count (e.g., 20 candidates for 10
+requested issues). Candidates must be:
+
+- **English-language** Project Gutenberg works.
+- **Major, well-known works of literature** with strong parser-coverage value — not filler
+  catalog entries.
+- **Broad across authors, periods, and structural styles.** Avoid clustering on one author
+  or era.
+- **Likely to exercise parser edge cases.** Favor works with:
+  - substantial front matter (prefaces, dedications, introductions)
+  - deep section nesting (parts → books → chapters → sub-sections)
+  - plays and dramatic works
+  - poetry collections
+  - epistolary / letter-based narratives
+  - essays and treatises
+  - translations with translator/editor matter
+  - unusual or complex tables of contents
+
+For each candidate, note the work title, expected PG ID, and a brief note on why it has
+parser-coverage value.
+
+## Step 3 — Resolve and deduplicate
+
+For each serious candidate:
+
+1. Confirm the correct Project Gutenberg edition and PG ID. Use the Gutenberg catalog or
+   `uv run gutenbit add <pg_id>` to verify the ID resolves to the expected work.
+2. Check the exclusion set from Step 1. Remove any candidate whose PG ID or title (fuzzy
+   match) is already seen.
+
+After deduplication, select the top `$ARGUMENTS` works from the remaining candidates, ranked
+by literary importance and expected parser-coverage value.
+
+## Step 4 — Create the parent issue
+
+Create a single parent issue in Linear:
+
+- **Team**: `Keinan`
+- **Project**: `Gutenbit`
+- **Labels**: `["Test"]`
+- **Priority**: `2` (High)
+- **Title**: `Discover <N> new English live battle cases and add them as templated subissues`
+- **Description**: Use this exact template, replacing `<N>` with the count:
+
+```markdown
+Create exactly <N> new child issues for live CLI/parsing battle tests. This issue is
+discovery and issue-creation only; do not run the battle tests here.
+
+## Selection criteria
+
+* English-language Project Gutenberg works only.
+* Prioritize major, well-known works of literature.
+* Each work is confirmed absent from existing Linear battle-test issues,
+  `tests/test_battle.py`, and the kei-17-corpus reference.
+* Breadth across authors, periods, and structural styles.
+
+## Child issues created
+
+(See sub-issues below.)
+```
+
+Record the parent issue identifier (e.g., `KEI-NNN`) for use in Step 5.
+
+## Step 5 — Create child issues
+
+For each of the selected works, create a child issue under the parent from Step 4.
+
+Every child issue must use this **exact description** — do not modify it per-work:
+
+```markdown
+Run a full live battle test of the CLI and parsing functionality for the work named in this issue title.
+
+Template rule:
+
+* Only customize the issue title, using `Gutenbit cli and parsing battle test: <work title>`.
+* Infer the target work from the title. Resolve the Project Gutenberg ID from the catalog if needed.
+
+Primary guide:
+
+* Use the `gutenbit-live-battle-test` skill.
+
+Start with:
+
+* Resolve the PG ID for the work named in the issue title.
+* `uv run gutenbit add <pg_id>`
+* `uv run gutenbit toc <pg_id>`
+* `uv run gutenbit search "<short distinctive query>" --book <pg_id>`
+* `uv run gutenbit view <pg_id>`
+
+Focus:
+
+* Inspect `toc` first for missing, extra, or mis-nested sections.
+* Compare any suspicious parser output against the raw Gutenberg HTML for the same PG work; treat that HTML as the truth.
+* If a parser bug is found, implement the smallest generalizable fix possible. No book-specific or PG-ID-specific rules.
+* Add a focused live regression in `tests/test_battle.py` if behavior needs to be locked in.
+* Before closing, run `uv run pytest` and `uv run pytest -m network`.
+
+Useful references:
+
+* `.claude/skills/gutenbit-live-battle-test/references/kei-17-corpus.md`
+* `tests/test_battle.py`
+* `AGENTS.md`
+
+Close-out should record either:
+
+* no parser issue found, with a brief note on why output matches the source HTML, or
+* the observed failure, the raw-HTML truth, the structural fix, the added regression test, and the verification run.
+```
+
+Each child issue must have:
+
+- **Title**: `Gutenbit cli and parsing battle test: <work title> - id <pg_id>`
+- **Team**: `Keinan`
+- **Project**: `Gutenbit`
+- **Labels**: `["Test"]`
+- **Priority**: `2` (High)
+- **Parent**: the parent issue identifier from Step 4
+
+Do **not** add work-specific notes to the child issue body. Keep it identical across all
+child issues — only the title changes.
+
+## Step 6 — Close out the parent
+
+After all child issues are created, leave a closing comment on the parent issue listing the
+created child issues. Use this format:
+
+```markdown
+## Created child issues
+
+| # | Work | PG ID | Issue |
+|---|------|-------|-------|
+| 1 | <title> | <pg_id> | <KEI-NNN> |
+| 2 | ... | ... | ... |
+...
+
+## Deduplication
+
+All <N> works confirmed absent from:
+- Linear issues matching `Gutenbit cli and parsing battle test:`
+- `tests/test_battle.py`
+- `.claude/skills/gutenbit-live-battle-test/references/kei-17-corpus.md`
+```
+
+## Acceptance criteria
+
+- Exactly `$ARGUMENTS` child issues are created under the parent.
+- All works are English-language and previously unseen.
+- All works are well-known literary works, not filler catalog entries.
+- Every child issue has an identical description (only the title differs).
+- The parent issue has a close-out comment listing all child issues and PG IDs.

--- a/.claude/skills/gutenbit-live-battle-test/SKILL.md
+++ b/.claude/skills/gutenbit-live-battle-test/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: gutenbit-live-battle-test
+description: >
+  Run and resolve live Gutenbit parsing and CLI battle tests for Project Gutenberg works.
+  Use when asked to battle test a new Gutenberg title, inspect gutenbit add/toc/view/search
+  output against raw Gutenberg HTML, diagnose parser failures, design a generalizable parser
+  fix, or add and update targeted regression tests without causing regressions on the existing
+  corpus. Also trigger for Linear issues titled "Gutenbit cli and parsing battle test: [title]",
+  requests to "run the battle test for [work]", "check how gutenbit parses [book]", or
+  "fix a parsing issue" for any Project Gutenberg work.
+---
+
+# Gutenbit Live Battle Test
+
+## Overview
+
+Use this skill to evaluate a real Project Gutenberg work end to end, compare Gutenbit's
+parsed structure against the source HTML, and turn any issue into a minimal, generalizable
+fix with focused regression coverage.
+
+Treat the raw Gutenberg HTML as the truth. Optimize for parser behavior that is fast,
+accurate, and generalizable to unseen works. Do not add book-specific heuristics keyed to a
+single title or Project Gutenberg ID.
+
+## Workflow
+
+### 1. Establish the target and current expectations
+
+Identify the Project Gutenberg ID, the suspected failure, and whether the task is discovery
+only or includes a fix.
+
+Before editing code:
+
+- Read `AGENTS.md` for the project's live-verification expectations and canonical corpus.
+- Read `tests/test_battle.py` to see how the current network regression suite expresses parser guarantees.
+- Read [references/kei-17-corpus.md](references/kei-17-corpus.md) to classify the issue against the 20 prior battle-test failures.
+
+### 2. Run the live CLI smoke test first
+
+Start with the real CLI because parser defects usually reveal themselves in visible structure
+before they are obvious in code.
+
+Run:
+
+```bash
+uv run gutenbit add <pg_id>
+uv run gutenbit toc <pg_id>
+uv run gutenbit view <pg_id>
+uv run gutenbit search "<query>" --book <pg_id>
+```
+
+Use `toc` as the primary structural signal. Use `view` and `search` to confirm whether the
+bad structure also damages navigation or search context.
+
+While inspecting output, write down:
+
+- missing sections
+- extra/synthetic sections
+- wrong nesting between `div1` / `div2` / `div3`
+- front matter or closing matter that disappeared
+- noisy attribution/publisher text that was promoted into headings
+- cases where the parser kept chapter headings but lost higher-level structure such as PART / BOOK / ACT
+
+### 3. Compare against raw Gutenberg HTML before forming a fix
+
+Do not infer the correct structure from intuition or another edition. Confirm it from the
+downloaded HTML for the same Gutenberg work.
+
+Use a small Python inspection snippet when needed:
+
+```python
+from gutenbit.download import download_html
+from gutenbit.html_chunker import chunk_html
+
+book_id = 0  # replace
+html = download_html(book_id)
+chunks = tuple(chunk_html(html))
+headings = [chunk for chunk in chunks if chunk.kind == "heading"]
+
+for heading in headings[:80]:
+    print(heading.div1, heading.div2, heading.div3, heading.content)
+```
+
+Also inspect the raw HTML directly to find the source anchors and heading tags that Gutenbit
+should preserve. Confirm:
+
+- which headings are real structure
+- which text is only contents scaffolding, attribution, or decorative matter
+- whether the TOC is incomplete and body-heading refinement is required
+- whether fallback heading scanning is over-triggering on speaker names, Roman numerals, or dramatic dialogue labels
+
+### 4. Classify the failure before changing code
+
+Map the bug to an existing failure class from [references/kei-17-corpus.md](references/kei-17-corpus.md).
+Most new regressions fit one of these families:
+
+- omitted opening matter
+- omitted closing matter
+- synthetic garbage headings
+- lost multi-level structure
+- catastrophic play parsing
+- attribution or publisher noise promoted into headings
+
+If the case does not fit an existing family, define the new family in structural terms, not
+title-specific terms.
+
+### 5. Design the smallest general fix
+
+Prefer fixes that improve the parser's structural rules rather than special-casing a single book.
+
+Good directions:
+
+- refine heading classification thresholds
+- improve TOC cleanup or heading normalization
+- refine body-heading fallback so it recovers real structure without promoting noise
+- preserve broad divisions such as BOOK / PART / ACT when lower-level headings also exist
+- suppress known non-structural patterns only when the rule is structurally justified
+
+Reject fixes that:
+
+- branch on a specific Project Gutenberg ID
+- key off an exact title or author when a structural pattern is available
+- fix the new book while weakening an existing corpus case
+- add wide heuristics without checking how they affect the network regression corpus
+
+State the intended invariant before editing code. Example: "preserve part-level headings as
+standalone sections instead of merging them into the first chapter heading."
+
+### 6. Add focused regression coverage
+
+Use `tests/test_battle.py` for live Gutenberg regression coverage. Follow the existing style:
+
+- write one test per behavioral guarantee
+- keep assertions tight and specific to the structural defect
+- assert the positive signal and the exclusion signal when both matter
+- use short heading slices for compact books and representative anchor assertions for long books
+- assert parent-child relationships through `div1` / `div2` / `div3` when hierarchy is the bug
+
+Examples of good test shapes:
+
+- assert the exact opening heading slice when front matter was missing
+- assert the exact closing heading slice when an epilogue or note was missing
+- assert that garbage headings are absent while the real headings remain
+- assert one or two representative nested headings for large multi-level works instead of snapshotting hundreds of headings
+
+Do not add broad snapshots that are hard to maintain and do not isolate the structural invariant.
+
+### 7. Verify in widening rings
+
+After the code change:
+
+1. Re-run the live CLI commands on the target book.
+2. Re-run the specific network regression that covers the target behavior.
+3. Re-run the full non-network suite.
+4. Re-run the full network battle corpus.
+
+Use:
+
+```bash
+uv run pytest tests/test_battle.py -k "<target>"
+uv run pytest
+uv run pytest -m network
+```
+
+Treat `uv run pytest -m network` as mandatory before closing the work unless network access
+is unavailable. The goal is not only to fix the new book, but to prove the parser still holds
+across the existing live corpus.
+
+### 8. Report the result in parser terms
+
+When documenting the outcome, summarize:
+
+- the observable CLI failure
+- the raw HTML truth that contradicted the parser output
+- the structural rule that changed
+- why the fix should generalize to unseen works
+- which focused and full-suite tests were run
+
+If no bug is present, record that explicitly and explain why the observed output matches the
+source HTML.
+
+## References
+
+- Read [references/kei-17-corpus.md](references/kei-17-corpus.md) for the 20 battle-test lessons and regression-writing heuristics.
+- Read `tests/test_battle.py` for the live corpus currently enforced in code.
+- Read `AGENTS.md` for the project's canonical working rules.

--- a/.claude/skills/gutenbit-live-battle-test/references/kei-17-corpus.md
+++ b/.claude/skills/gutenbit-live-battle-test/references/kei-17-corpus.md
@@ -1,0 +1,59 @@
+# KEI-17 Battle-Test Corpus
+
+Use this file to classify new failures quickly and to mirror the test-writing style already established in `tests/test_battle.py`.
+
+## Failure classes
+
+| Work | PG ID | Failure class | Key lesson |
+| --- | ---: | --- | --- |
+| Hamlet | 1122 | Catastrophic play parsing | Recover act/scene structure; do not let `FINIS` collapse the play. |
+| Macbeth | 1129 | Catastrophic play parsing | Paragraph fallback can recover full play structure when TOC links fail. |
+| The Republic | 150 | Lost top-level structure | Preserve `BOOK I` through `BOOK X` over speaker headings. |
+| Faust -- Part 1 | 3023 | Synthetic dramatic headings | Keep top-level dramatic sections; reject character/speech labels as structure. |
+| The Canterbury Tales | 2383 | Garbage Roman numeral headings | Do not promote stray single-letter or numeral headings; keep real book divisions. |
+| The Inferno | 41537 | Garbage front-matter headings | Reject stray numeral sections before the real canto sequence. |
+| Leviathan | 3207 | Lost deep structure | Refine beyond the TOC when body headings expose real subsections. |
+| Moby-Dick | 15 | Omitted opening matter | Preserve `ETYMOLOGY` and `EXTRACTS` before chapter one. |
+| Dracula | 345 | Omitted closing matter | Preserve the final `NOTE` after the last chapter. |
+| Middlemarch | 145 | Omitted closing matter | Preserve `FINALE` and closing sections after the last numbered chapter. |
+| Jane Eyre | 1260 | Omitted opening matter | Keep `PREFACE` and edition notes before chapter one. |
+| Les Miserables | 135 | Omitted opening and closing matter | Keep preface material and the final letter. |
+| A Christmas Carol | 46 | Omitted opening matter | Preserve `PREFACE` before the stave sequence. |
+| Tom Sawyer | 74 | Omitted opening matter | Preserve `PREFACE` before chapter one. |
+| Gulliver's Travels | 829 | Omitted opening matter | Preserve prefatory letters before `PART I`. |
+| Don Quixote | 996 | Omitted opening matter | Keep the prefatory block and commendatory verses. |
+| Bleak House | 1023 | Omitted opening matter | Preserve `PREFACE` before chapter one. |
+| Vanity Fair | 599 | Omitted opening matter | Preserve `BEFORE THE CURTAIN` before chapter one. |
+| Black Beauty | 271 | Lost part-level structure | Keep part headings as standalone sections instead of merging them into chapters. |
+| Candide | 19942 | Attribution/publisher noise | Keep real front matter and reject publisher/credit lines as headings. |
+
+## Patterns to reuse
+
+- Prefer structural explanations over title-specific explanations. "speaker labels are being mistaken for headings" is useful; "The Republic is weird" is not.
+- Compare the parsed TOC against raw HTML for the same edition. Do not use another Gutenberg edition or a print edition as the ground truth.
+- Expect the broad failure families above to recur in unseen works. Design fixes around the family, not the current title.
+- Be especially cautious with Roman numerals, speaker names, dramatic labels, attribution lines, publisher lines, and contents scaffolding.
+- When the TOC is incomplete, look for real heading structure in the body before concluding the book is unstructured.
+
+## Test-writing heuristics from `tests/test_battle.py`
+
+- Name the test after the parser guarantee, not the issue number.
+- Assert the smallest slice that proves the regression is fixed.
+- Use exact heading slices for compact opening/closing matter regressions.
+- Use representative anchor assertions for large books. `Leviathan` proves nested structure with a few specific headings instead of a full snapshot.
+- Assert both presence and absence when the bug has a noisy false-positive mode. `Candide`, `Faust`, `Canterbury`, and `Inferno` all follow this pattern.
+- Assert parent-child structure explicitly when hierarchy matters. The play and multi-level tests rely on `div1`, `div2`, and `div3`.
+- Avoid brittle counts unless the count itself is the invariant. For some books the exact number of headings matters; for others a few anchor headings are better.
+- Keep live tests book-specific and readable. A future reader should understand the regression from the test name and the assertions alone.
+
+## Verification standard
+
+After fixing one book, check the whole live corpus:
+
+```bash
+uv run pytest tests/test_battle.py -k "<target>"
+uv run pytest
+uv run pytest -m network
+```
+
+The target book passing is necessary but not sufficient. The fix is only done when the broader corpus still holds.


### PR DESCRIPTION
## Summary
- Adds four custom Claude Code skills for the project: battle testing, changelog generation, CLI API review, and battle test discovery
- Includes a reference corpus file for the battle test skill listing known test works

## Test plan
- [x] Verify skills load correctly in Claude Code (`/mcp` or skill list)
- [x] Run each skill to confirm it works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)