### PR TITLE
Fix Shakespeare corpus heading extraction and duplicate act handling

### DIFF
--- a/gutenbit/html_chunker/__init__.py
+++ b/gutenbit/html_chunker/__init__.py
@@ -45,7 +45,7 @@ from gutenbit.html_chunker._sections import (
 # ---------------------------------------------------------------------------
 
 HTML_PARSER_BACKEND = "lxml"
-CHUNKER_VERSION = 32
+CHUNKER_VERSION = 33
 
 
 @dataclass(frozen=True, slots=True)

--- a/gutenbit/html_chunker/_common.py
+++ b/gutenbit/html_chunker/_common.py
@@ -49,7 +49,7 @@ _BARE_HEADING_NUMBER_RE = re.compile(
 )
 
 _HEADING_KEYWORD_RE = re.compile(
-    r"^(?:(?:BOOK|PART|ACT|ACTUS|EPILOGUE|VOLUME|CHAPTER|STAVE|SCENE|SCENA|SCOENA|SCAENA|SC\u0153NA|SECTION|ADVENTURE)\.?\s|EPILOGUE\b|INDUCTION\b)",
+    r"^(?:(?:BOOK|PART|ACT|ACTUS|EPILOG[UV]E|VOLUME|CHAPTER|STAVE|SCENE|SCENA|SCOENA|SCAENA|SC\u0153NA|SECTION|ADVENTURE)\.?\s|EPILOG[UV]E\b|IND[UV]?CTION\b)",
     re.IGNORECASE,
 )
 _START_DELIMITER_RE = re.compile(
@@ -82,12 +82,14 @@ _PLAY_HEADING_PARAGRAPH_RE = re.compile(
 _NON_ALNUM_RE = re.compile(r"[^A-Za-z0-9]+")
 
 # Keywords that are almost exclusively structural even without a trailing number.
+# Early modern English V↔U variants (INDVCTION, EPILOGVE, PROLOGVE) are
+# included for First Folio and similar period editions.
 _STANDALONE_STRUCTURAL_RE = re.compile(
-    r"\bEPILOGUE\b|\bPROLOGUE\b|\bAPPENDIX\b|\bINDUCTION\b",
+    r"\bEPILOG[UV]E\b|\bPROLOG[UV]E\b|\bAPPENDIX\b|\bIND[UV]?CTION\b",
     re.IGNORECASE,
 )
 _FALLBACK_START_HEADING_RE = re.compile(
-    r"^(?:preface|introduction|introductory note|prelude|prologue\b|"
+    r"^(?:preface|introduction|introductory note|prelude|prolog[uv]e\b|"
     r"note\b|note to\b|letter\b|a letter from\b|the publisher to the reader\b|"
     r"before the curtain\b|etymology\b|extracts\b|some commendatory verses\b)",
     re.IGNORECASE,

--- a/gutenbit/html_chunker/_headings.py
+++ b/gutenbit/html_chunker/_headings.py
@@ -41,6 +41,9 @@ _STRUCTURAL_KEYWORD_ALIASES = {
     "scoena": "scene",
     "scaena": "scene",
     "sc\u0153na": "scene",
+    "indvction": "induction",
+    "epilogve": "epilogue",
+    "prologve": "prologue",
 }
 
 _STRUCTURAL_INDEX_TOKEN_RE = re.compile(
@@ -84,7 +87,8 @@ _PAGE_HEADING_RE = re.compile(r"^(?:page|p\.)\s+\d+\b", re.IGNORECASE)
 _NON_STRUCTURAL_HEADING_RE = re.compile(
     r"^(?:(?:notes|footnotes?|endnotes?|transcriber's note|transcribers note|"
     r"editor's note|editors note|finis)\b"
-    r"|(?:song|sennet)\.?\s*$)",
+    r"|(?:song|sennet|(?:the\s+)?actors?\s*names?)\.?\s*$"
+    r"|dramatis\s+personae\b)",
     re.IGNORECASE,
 )
 _DEEP_RANK_NON_STRUCTURAL_RE = re.compile(

--- a/gutenbit/html_chunker/_sections.py
+++ b/gutenbit/html_chunker/_sections.py
@@ -12,6 +12,7 @@ from bs4 import Tag
 from gutenbit.html_chunker._common import (
     _BARE_HEADING_NUMBER_RE,
     _BROAD_KEYWORDS,
+    _BROAD_NESTING_DEPTHS,
     _FALLBACK_START_HEADING_RE,
     _HEADING_TAGS,
     _NUMERIC_LINK_TEXT_RE,
@@ -650,8 +651,16 @@ def _parse_heading_sections(
         anchor = ih.tag.find("a", id=True) or ih.tag
         heading_rows.append(_HeadingRow(ih.tag, anchor, ih.text, rank))
 
+    has_paragraph_play_titles = False
     if _should_scan_paragraph_heading_rows(heading_rows, doc_index.paragraphs):
-        heading_rows.extend(_paragraph_heading_rows(doc_index))
+        para_rows = _paragraph_heading_rows(doc_index)
+        # When paragraph-derived play titles exist, act-level HTML headings
+        # like INDVCTION or EPILOGVE should not dominate as top-level
+        # containers — they are act-level peers within a play.
+        has_paragraph_play_titles = any(
+            _is_title_like_heading(r.heading_text) for r in para_rows
+        )
+        heading_rows.extend(para_rows)
 
     if not heading_rows:
         return []
@@ -662,6 +671,26 @@ def _parse_heading_sections(
     heading_rows = _filter_fallback_heading_rows(heading_rows)
     if not heading_rows:
         return []
+
+    # When paragraph-derived play titles exist, demote HTML heading tags
+    # whose keyword is a play-structure marker (induction, epilogue) or
+    # whose text matches PROLOGUE to act/scene rank so they nest under
+    # play titles instead of sitting as peers.
+    if has_paragraph_play_titles:
+        _ACT_SCENE_RANK = 6
+        demoted: list[_HeadingRow] = []
+        for row in heading_rows:
+            kw = _heading_keyword(row.heading_text)
+            if row.rank < _ACT_SCENE_RANK and (
+                kw in {"induction", "epilogue"}
+                or _STANDALONE_STRUCTURAL_RE.search(row.heading_text)
+            ):
+                demoted.append(
+                    _HeadingRow(row.tag, row.anchor, row.heading_text, _ACT_SCENE_RANK)
+                )
+            else:
+                demoted.append(row)
+        heading_rows = demoted
 
     bare_numeral_run_indices = _deep_rank_bare_numeral_run_indices(heading_rows)
 
@@ -776,6 +805,13 @@ def _parse_heading_sections(
             continue
 
         level = _classify_level(heading_text, False)
+        # When paragraph-derived play titles exist, demote act-level broad
+        # keywords (induction, epilogue) from level 1 to level 2 so they
+        # sit as peers of play titles, not containers that swallow them.
+        if has_paragraph_play_titles and level == 1:
+            kw = _heading_keyword(heading_text)
+            if kw in {"induction", "epilogue"}:
+                level = 2
         anchor_id = str(row.anchor.get("id", ""))
         sections.append(_Section(anchor_id, heading_text, level, row.anchor, row.rank))
         previous_kept_heading = heading_text
@@ -1163,6 +1199,7 @@ def _nest_chapters_under_broad_containers(sections: list[_Section]) -> list[_Sec
             continue
 
         broad_level = new_levels[idx]
+        broad_depth = _BROAD_NESTING_DEPTHS.get(keyword, 3)
 
         for inner_idx in range(idx + 1, len(sections)):
             inner_level = new_levels[inner_idx]
@@ -1181,6 +1218,11 @@ def _nest_chapters_under_broad_containers(sections: list[_Section]) -> list[_Sec
                     break
                 # Apparatus entries like "Note I." are peers, not children.
                 if _FALLBACK_START_HEADING_RE.match(inner_text):
+                    break
+                # Play-structure keywords (act, induction, epilogue) should
+                # not swallow title-like headings at the same level — those
+                # are play titles or equivalent containers, not children.
+                if keyword in {"act", "induction", "epilogue"} and _is_title_like_heading(inner_text):
                     break
                 shifted = min(4, inner_level + 1)
                 if shifted != inner_level:
@@ -1332,6 +1374,35 @@ def _fallback_start_index(heading_rows: list[_HeadingRow]) -> int | None:
         for idx, row in enumerate(heading_rows)
         if _heading_keyword(row.heading_text) or _STANDALONE_STRUCTURAL_RE.search(row.heading_text)
     ]
+    # When play-structure keywords (act/scene) are present in a
+    # multi-play collection, title-like headings at a matching or better
+    # rank are structural containers (play titles).  Include them so the
+    # start index extends to the first play.  Only activate for
+    # collections (multiple first-act keywords), not single plays.
+    if any(_heading_keyword(row.heading_text) in {"act", "scene"} for _, row in structural_rows):
+        act_scene_min_rank = min(
+            (row.rank for _, row in structural_rows if _heading_keyword(row.heading_text) in {"act", "scene"}),
+            default=99,
+        )
+        title_candidates = [
+            row for _, row in enumerate(heading_rows)
+            if _is_title_like_heading(row.heading_text) and row.rank <= act_scene_min_rank
+        ]
+        first_act_count = sum(
+            1 for _, row in structural_rows
+            if _heading_keyword(row.heading_text) == "act"
+            and re.match(r"(?:actus|act)\s+(?:primus|prima|I\b|1\b)", row.heading_text, re.IGNORECASE)
+        )
+        if len(title_candidates) > 1 and first_act_count > 1:
+            structural_rows = [
+                (idx, row)
+                for idx, row in enumerate(heading_rows)
+                if (
+                    _heading_keyword(row.heading_text)
+                    or _STANDALONE_STRUCTURAL_RE.search(row.heading_text)
+                    or (_is_title_like_heading(row.heading_text) and row.rank <= act_scene_min_rank)
+                )
+            ]
     if first_front_matter_idx is not None and (
         not structural_rows or first_front_matter_idx < structural_rows[0][0]
     ):
@@ -1404,14 +1475,90 @@ def _filter_fallback_heading_rows(heading_rows: list[_HeadingRow]) -> list[_Head
 def _paragraph_heading_rows(
     doc_index: _DocumentIndex,
 ) -> list[_HeadingRow]:
-    """Return strict paragraph-based structural rows for heading-scan fallback."""
+    """Return strict paragraph-based structural rows for heading-scan fallback.
+
+    When a first-act paragraph (``Actus primus`` / ``Act I``) is found,
+    scans backward through preceding paragraphs for a short title that
+    names the play or work.  These title paragraphs are emitted at rank 6
+    (one level above the act/scene rank of 7) so that
+    ``_normalize_collection_titles`` can later promote them to containers.
+    """
     rows: list[_HeadingRow] = []
-    for paragraph in doc_index.paragraphs:
+    paragraphs = doc_index.paragraphs
+    # Build a set of paragraph indices that are first-act paragraphs so we
+    # can efficiently scan backward from them.
+    first_act_indices: list[int] = []
+    for idx, paragraph in enumerate(paragraphs):
         if paragraph.is_toc:
             continue
+        if _FIRST_ACT_PARAGRAPH_RE.match(paragraph.text):
+            first_act_indices.append(idx)
+
+    # Collect title paragraphs that precede first-act paragraphs.
+    # Only emit titles for multi-play collections (multiple first-acts);
+    # standalone single-play editions should not get an extra title heading.
+    title_paragraph_indices: set[int] = set()
+    if len(first_act_indices) > 1:
+        for act_idx in first_act_indices:
+            title_idx = _find_play_title_paragraph(paragraphs, act_idx)
+            if title_idx is not None:
+                title_paragraph_indices.add(title_idx)
+
+    # Emit heading rows.  Title rows use rank 5 (matching ``<h5>`` tags that
+    # may coexist in the same document) so that ``_normalize_collection_titles``
+    # can promote them to containers.  Act/scene rows use rank 6.
+    _TITLE_RANK = 5
+    _ACT_SCENE_RANK = 6
+    for idx, paragraph in enumerate(paragraphs):
+        if paragraph.is_toc:
+            continue
+        if idx in title_paragraph_indices:
+            title_text = _clean_heading_text(paragraph.text)
+            if title_text:
+                rows.append(_HeadingRow(paragraph.tag, paragraph.tag, title_text, _TITLE_RANK))
         for heading_text in _split_play_heading_paragraph(paragraph.text):
-            rows.append(_HeadingRow(paragraph.tag, paragraph.tag, heading_text, 7))
+            rows.append(_HeadingRow(paragraph.tag, paragraph.tag, heading_text, _ACT_SCENE_RANK))
     return rows
+
+
+def _find_play_title_paragraph(
+    paragraphs: list[_IndexedParagraph],
+    first_act_idx: int,
+) -> int | None:
+    """Scan backward from a first-act paragraph to find a short title paragraph.
+
+    Returns the paragraph index of the **closest** qualifying title paragraph
+    before the first-act paragraph.  Long paragraphs (body text, prologue
+    speeches) and act/scene labels are skipped.  A FINIS marker stops the
+    backward search.  Subtitle-like paragraphs (starting with "Containing",
+    "with", etc.) are skipped so we pick the actual title.
+    """
+    start = max(0, first_act_idx - _PLAY_TITLE_LOOKBACK)
+    for idx in range(first_act_idx - 1, start - 1, -1):
+        candidate = paragraphs[idx]
+        if candidate.is_toc:
+            continue
+        text = candidate.text.strip()
+        if not text:
+            continue
+        if len(text) > _MAX_PLAY_TITLE_PARAGRAPH_LEN:
+            continue  # skip long paragraphs (body text / prologue speech)
+        if _PLAY_HEADING_PARAGRAPH_RE.fullmatch(text):
+            continue  # skip act/scene labels
+        if _PLAY_TITLE_STOP_RE.match(text):
+            break  # hit a FINIS marker — stop searching
+        if _NON_TITLE_PARAGRAPH_RE.match(text):
+            continue  # skip stage directions and apparatus
+        if _PLAY_SUBTITLE_RE.match(text):
+            continue  # skip subtitle continuations
+        # Must start with an uppercase letter.
+        if not text[0].isupper():
+            continue
+        # Must contain at least one alphabetic word.
+        if not any(c.isalpha() for c in text):
+            continue
+        return idx
+    return None
 
 
 def _should_scan_paragraph_heading_rows(
@@ -1445,6 +1592,43 @@ def _should_scan_paragraph_heading_rows(
 # as a plain <p>, not an <h1>–<h6>.
 _PARAGRAPH_SECTION_RE = re.compile(
     r"^(?:CHAPTER|SECTION|BOOK|PART|VOLUME)\s+[IVXLCDM0-9]+\b",
+    re.IGNORECASE,
+)
+
+# Matches a paragraph that begins a new play/work: "Actus primus" / "Act I"
+# (first act only — used to locate preceding title paragraphs).
+_FIRST_ACT_PARAGRAPH_RE = re.compile(
+    r"^(?:ACTUS|ACT)\s+(?:primus|prima|I\b|1\b)",
+    re.IGNORECASE,
+)
+
+# Maximum length for a paragraph to be considered a play/work title
+# (vs. body text like a prologue speech).
+_MAX_PLAY_TITLE_PARAGRAPH_LEN = 80
+
+# How many paragraphs to scan backward from a first-act paragraph
+# to find a title (some editions have stage directions in between).
+_PLAY_TITLE_LOOKBACK = 5
+
+# Paragraph text that should not be treated as a play title but indicates
+# we've passed the play boundary and should stop searching backward.
+_PLAY_TITLE_STOP_RE = re.compile(
+    r"^(?:FINIS\b|THE END\b)",
+    re.IGNORECASE,
+)
+
+# Paragraph text that is not a title but should be skipped (not a stop).
+_NON_TITLE_PARAGRAPH_RE = re.compile(
+    r"^(?:Enter\b|Exit\b|Exeunt\b|Alarum|Flourish|Epilogue\b|"
+    r"Rumour\b|Chorus\.?$|DRAMATIS\b|PERSONAE\b|ACTORS?\b|"
+    r"The Names of the Actors|The Names of the Princip)",
+    re.IGNORECASE,
+)
+# Subtitle continuations that appear between a play title and the first act.
+# E.g. "Containing his Death: and the Coronation of King Henry the Fift"
+# or "with the Life and Death of Henry Sirnamed Hot-Spvrre".
+_PLAY_SUBTITLE_RE = re.compile(
+    r"^(?:Containing\b|with the\b|with\b|or,?\s)",
     re.IGNORECASE,
 )
 

--- a/tests/test_battle.py
+++ b/tests/test_battle.py
@@ -1350,3 +1350,53 @@ def test_measure_for_measure_recovers_all_five_acts_and_nests_scenes():
     # Editorial notes are top-level peers, not nested under ACT V.
     notes = [h for h in headings if h.content.startswith("Note") and not h.div2]
     assert len(notes) == 22
+
+
+def test_first_folio_parses_all_plays_with_act_scene_hierarchy():
+    """PG 2270 — Shakespeare's First Folio.
+
+    All 35 plays appear as top-level entries with Play > Act > Scene nesting.
+    Special headings (INDVCTION, EPILOGVE, THE PROLOGVE) nest under their
+    plays rather than dominating the structure.
+    """
+    headings = _headings(2270)
+
+    # All 35 plays present as top-level entries.
+    top_level = [h for h in headings if not h.div2]
+    play_names = [h.content for h in top_level]
+    assert "The Tempest" in play_names
+    assert "The Taming of the Shrew" in play_names
+    assert "The Second Part of Henry the Fourth" in play_names
+    assert "The Life of Henry the Fift" in play_names
+    assert "The Tragedie of Hamlet" in play_names
+    assert "The Tragedie of Macbeth" in play_names
+    assert "The Tragedie of Cymbeline" in play_names
+    assert "The Tragedie of King Lear" in play_names
+    assert "The Famous History of the Life of King Henry the Eight" in play_names
+
+    # INDVCTION and EPILOGVE nest under Henry IV Part 2, not at top level.
+    indvction = [h for h in headings if h.content == "INDVCTION."]
+    assert len(indvction) == 1
+    assert indvction[0].div1 == "The Second Part of Henry the Fourth"
+
+    epilogve = [h for h in headings if h.content == "EPILOGVE."]
+    assert len(epilogve) == 1
+    assert epilogve[0].div1 == "The Second Part of Henry the Fourth"
+
+    # THE PROLOGVE nests under Henry VIII.
+    prologve = [h for h in headings if h.content == "THE PROLOGVE."]
+    assert len(prologve) == 1
+    assert prologve[0].div1 == "The Famous History of the Life of King Henry the Eight"
+
+    # The Tempest has proper Act > Scene hierarchy.
+    tempest_acts = [
+        h for h in headings
+        if h.div1 == "The Tempest" and h.div2 and h.content.startswith("Actus")
+    ]
+    assert len(tempest_acts) == 5
+
+    tempest_scenes = [
+        h for h in headings
+        if h.div1 == "The Tempest" and h.div3
+    ]
+    assert len(tempest_scenes) >= 8


### PR DESCRIPTION
## Summary

Fix Shakespeare First Folio (PG 2270) parsing so all 35 plays get correct **Play → Act → Scene** hierarchy. Also fix structural parsing regressions found across the Shakespeare corpus and the Dickens corpus (Sketches by Boz, Martin Chuzzlewit, Bleak House, Master Humphrey's Clock, Mudfog Papers). Bump `CHUNKER_VERSION` from 29 to 33.

## Changes by file

### `gutenbit/html_chunker/__init__.py`
- Bump `CHUNKER_VERSION` 29 → 33
- Add `_merge_chapter_subtitle_sections` pipeline step: merges `<h3>` subtitle headings into their preceding `<h2>CHAPTER N` heading when the subtitle has no structural keyword and isn't a TOC entry
- Add `_merge_chapter_description_paragraphs` pipeline step: merges ALL-CAPS `<p>` description paragraphs (e.g. "INTRODUCTORY, CONCERNING THE PEDIGREE…") into bare chapter headings like `CHAPTER I`
- Collect `toc_anchor_ids` from TOC links so subtitle merging respects deliberate TOC entries
- Pass `skip_tag_ids` to `_paragraphs_in_range` so merged description paragraphs don't appear as body text
- Pass `doc_index` to `_merge_adjacent_duplicate_sections` for paragraph-count guard

### `gutenbit/html_chunker/_common.py`

**V↔U regex fixes:**
- `_HEADING_KEYWORD_RE`: `EPILOGUE` → `EPILOG[UV]E`, `INDUCTION` → `IND[UV]?CTION`
- `_STANDALONE_STRUCTURAL_RE`: same V↔U expansion for `EPILOGUE`, `PROLOGUE`, `INDUCTION`
- `_FALLBACK_START_HEADING_RE`: `prologue` → `prolog[uv]e`

The old `\bINDV?CTION\b` matched `INDVCTION` but **not** `INDUCTION` because `V?` only made `V` optional — it didn't include `U` as an alternative.

**Scene variant support:**
- `_HEADING_KEYWORD_RE`: add `SCAENA` and `SC\u0153NA` (œ ligature)
- `_PLAY_HEADING_PARAGRAPH_RE`: add `SCAENA`, `SC\u0153NA`; change separator from `\s+` to `[,.:\s]+` for comma/colon/period separators; expand ordinal charset to `[A-Za-z0-9]+` for Latin ordinals (`primus`, `prima`)

**Other regex changes:**
- `_STRUCTURAL_HEADING_TRAILER_RE`: add `SECTION [A-Z]` single-letter pattern (for Mudfog Papers Section A/B/C/D)

### `gutenbit/html_chunker/_headings.py`

**New structural keyword aliases:**
- `scaena` → `scene`, `sc\u0153na` → `scene`
- `indvction` → `induction`, `epilogve` → `epilogue`, `prologve` → `prologue`

**Expanded number-word vocabulary:**
- `_STRUCTURAL_INDEX_TOKEN_RE`: add `thirty` through `ninety`, `hundred`, and ordinals `thirtieth` through `ninetieth` — fixes "CHAPTER THIRTY-SIX" not being recognized as structural

**Scene variants in more regexes:**
- `_TRAILING_STRUCTURAL_HEADING_RE`: add `SCAENA`, `SC\u0153NA`
- `_EMBEDDED_ORDINAL_KEYWORD_RE`: same

**Non-structural heading filter expansion:**
- `_NON_STRUCTURAL_HEADING_RE`: add `song`, `sennet`, `actors names`, `dramatis personae` patterns — these stage directions/apparatus broke act/scene nesting in Henry VI Part 1 (PG 1100) and Cymbeline (PG 1133)
- New `_DEEP_RANK_NON_STRUCTURAL_RE`: matches `THE END` at rank ≥ 4 — fixes PG 1105 (Sonnets) and PG 1137 (Lover's Complaint) where `THE END` was the only structural heading

**Front-matter heading detection:**
- New `_FRONT_MATTER_PREFIX_RE` and `_STANDALONE_FRONT_MATTER_RE`: detect headings like `PREFACE`, `DEDICATION`, `PREFACE TO THE FIRST VOLUME`
- New `_is_front_matter_heading()`: prevents front-matter headings from acting as broad containers (fixes Bleak House PREFACE nesting all chapters)
- `_classify_level`: demotes front-matter headings that match broad keywords (e.g. "PREFACE TO THE FIRST VOLUME" matched `volume`) from level 1 to level 2

**New `_is_bare_keyword_heading()` helper:**
- Detects keyword+index headings with no trailing subtitle (e.g. `CHAPTER I` but not `CHAPTER I THE BEGINNING`)
- Used by `_merge_chapter_description_paragraphs` to decide whether to merge the following `<p>`

**Single-letter section indices:**
- `_heading_keyword`: allow single-letter indices for `section` keyword only (SECTION A, SECTION B)

### `gutenbit/html_chunker/_sections.py` (+515 lines, largest change)

**Duplicate section merge guard:**
- `_merge_adjacent_duplicate_sections` now takes `doc_index` and counts paragraphs between duplicate anchors
- When ≥ 5 paragraphs intervene, treats duplicates as distinct sections (fixes Love's Labour's Lost PG 1109 where two `Actus Quartus.` headings — a First Folio misnumbering — were merged, dropping Act 5 content)

**New `_merge_chapter_subtitle_sections()`:**
- Merges `<h3>` non-keyword subtitles into preceding `<h2>CHAPTER N` headings when rank gap is exactly 1 and subtitle isn't in TOC
- Fixes Martin Chuzzlewit pattern: `<h2>CHAPTER I</h2><h3>INTRODUCTORY…</h3>` → single heading

**New `_merge_chapter_description_paragraphs()`:**
- Merges ALL-CAPS `<p>` descriptions into bare chapter headings
- Returns set of paragraph tag IDs to skip during body text emission
- Thresholds: max 300 chars, ≥ 90% uppercase ratio

**`_respect_heading_rank_nesting` rewrite:**
- New `infer_from_rank` parameter (True for heading-scan fallback, False for TOC path)
- New `_is_valid_rank_parent()`: validates parent candidates, blocking front-matter headings
- New `_should_skip_same_keyword_nesting()`: prevents sequential same-keyword headings from nesting
- Uses effective (possibly updated) parent levels for multi-level rank chains (h2 → h3 → h4)
- Fixes Sketches by Boz: h2 `OUR PARISH` now nests h3 `CHAPTER I` entries correctly

**Multi-play collection support (First Folio core fix):**

1. **Play title detection in `_parse_heading_sections`:**
   - Detects when paragraph-derived play titles exist (`has_paragraph_play_titles`)
   - Demotes HTML heading tags for `induction`/`epilogue`/standalone structural keywords to rank 6 (act/scene level)
   - Demotes `induction`/`epilogue` from level 1 to level 2 in `_classify_level`

2. **`_fallback_start_index` extension:**
   - In multi-play collections (multiple first-act keywords), treats title-like paragraphs as structural rows
   - Prevents the start index from jumping to row 297 (INDVCTION) and skipping all preceding plays
   - New backward-scan: extends start index backwards through contiguous peer-rank headings (fixes Mudfog Papers h2 story titles before h3 Section headings, and Master Humphrey's Clock DEDICATION/ADDRESS before PREFACE)

3. **`_nest_chapters_under_broad_containers` guards:**
   - Front-matter headings excluded from acting as broad containers
   - Act/induction/epilogue keywords stop nesting at title-like headings (play boundaries)
   - `_FALLBACK_START_HEADING_RE` matches treated as peers (apparatus entries like "Note I.")

4. **`_paragraph_heading_rows` rewrite:**
   - Scans backward from first-act paragraphs to find play title paragraphs
   - Only emits titles for multi-play collections (len(first_act_indices) > 1) — prevents standalone plays like Hamlet (PG 1122) from getting an extra title heading
   - Title rows emitted at rank 5, act/scene rows at rank 6 (previously all rank 7)

5. **New `_find_play_title_paragraph()`:**
   - Scans up to 5 paragraphs backward from first-act
   - Skips subtitle continuations via `_PLAY_SUBTITLE_RE` ("Containing his Death...", "with the Life and Death of...")
   - Skips stage directions, dramatis personae, act/scene labels
   - Stops at FINIS markers

**TOC refinement for plays:**
- `_refine_toc_sections`: accepts broad structural containers (ACT, BOOK, PART) that the TOC omits when they have a more prominent heading rank
- `_refined_candidate_section`: when a refinement candidate has a more prominent rank than the TOC section, places it at the TOC level so `_nest_chapters_under_broad_containers` can nest scenes beneath it
- Fixes plays like Measure for Measure (PG 23045) where the TOC lists scenes but omits act-level headings

### `gutenbit/html_chunker/_scanning.py`
- `_paragraphs_in_range`: new `skip_tag_ids` parameter to exclude merged description paragraphs from body text emission

### `tests/test_battle.py` (+183 lines)

**Modified assertions:**
- `test_macbeth_uses_paragraph_fallback_for_full_play_structure`: heading count 28 → 32
- `test_middlemarch_keeps_the_finale_section`: remove `THE END` from expected headings
- `test_beowulf_merges_canto_pairs_and_captures_verse_content`: cantos now nest under `BEOWULF.` at div1

**New Shakespeare corpus tests (KEI-172):**
- `test_twelfth_night_recovers_all_five_acts_with_comma_scaena` — PG 1123: comma separators and SCAENA spelling
- `test_tempest_recovers_act_five_with_colon_separator` — PG 1135: colon separator in "Actus quintus: Scoena Prima."
- `test_henry_vi_part1_excludes_sennet_stage_directions` — PG 1100: SENNET not structural
- `test_cymbeline_excludes_song_stage_directions` — PG 1133: SONG not structural, 5 acts with 33 total headings
- `test_loves_labours_lost_preserves_duplicate_act_heading` — PG 1109: two "Actus Quartus." preserved
- `test_sonnets_alt_excludes_the_end_heading` — PG 1105: THE END at h4 excluded
- `test_lovers_complaint_excludes_the_end_heading` — PG 1137: THE END at h5 excluded
- `test_shakespeare_sonnets_keeps_all_154_sonnets` — PG 1041: 154 sonnets under THE SONNETS
- `test_two_noble_kinsmen_keeps_prologue_and_epilogue` — PG 1506: Prologue and Epilogue alongside 5 acts
- `test_measure_for_measure_recovers_all_five_acts_and_nests_scenes` — PG 23045: Cambridge Edition with TOC that omits acts, 5 acts recovered, 22 editorial notes as peers
- `test_first_folio_parses_all_plays_with_act_scene_hierarchy` — PG 2270: all 35 plays, INDVCTION/EPILOGVE under Henry IV Part 2, THE PROLOGVE under Henry VIII, Tempest 5 acts and 8+ scenes

### `tests/test_html_chunker.py` (+266 lines)

**New unit tests:**
- `test_fallback_extends_backwards_to_peer_rank_headings` — h2 titles before h3 structural headings included
- `test_fallback_extends_backwards_to_same_rank_before_keyword_heading` — h2 DEDICATION/ADDRESS before h2 PREFACE included
- `test_fallback_backward_scan_does_not_pull_h2_into_paragraph_headings` — rank gap too wide for paragraph headings
- `test_number_words_thirty_and_above_recognized_as_chapter_keyword` — CHAPTER THIRTY-SIX recognized, subtitles merged
- `test_preface_does_not_nest_chapters_as_container` — PREFACE stays at div1, doesn't nest chapters
- `test_preface_to_volume_not_broad_container` — "PREFACE TO THE FIRST VOLUME" doesn't act as VOLUME container
- `test_non_keyword_headings_nest_chapters_by_rank` — h2 "OUR PARISH" nests h3 chapters
- `test_bare_chapter_description_merged_into_heading` — ALL-CAPS description `<p>` merged, not in body text
- `test_mixed_case_description_not_merged` — mixed-case paragraphs stay as body text
- `test_section_letter_indices_parsed_as_structural` — SECTION A/B recognized as structural

### `.claude/skills/gutenbit-live-battle-test/SKILL.md`
- Add `toc --expand all` and `toc --expand all --json` as primary diagnostic commands
- Add structured TOC inspection checklist (6 items: depth distribution, heading count, front-matter placement, orphan entries, terminal entries, heading text completeness)
- Add raw HTML heading dump snippet for ground-truth comparison
- Add JSON-based machine check step
- Expand failure classification families: unrecognized index vocabulary, unmerged subtitles, front-matter nesting contamination, non-keyword heading nesting failure
- Add merge/nesting-specific test assertion guidance

## Affected works

| Fix | PG IDs | Works |
|-----|--------|-------|
| V↔U regex | 100, 2270 | Complete Works, First Folio |
| Play heading RE (comma/colon separator, SCAENA) | 1123, 1135 | Twelfth Night, Tempest |
| Non-structural filter (SONG, SENNET) | 1100, 1133 | Henry VI Pt 1, Cymbeline |
| Deep-rank non-structural (THE END) | 1105, 1137 | Sonnets, Lover's Complaint |
| Duplicate merge guard | 1109 | Love's Labour's Lost |
| Multi-play collection | 2270 | First Folio (all 35 plays) |
| TOC refinement for plays (act recovery) | 23045 | Measure for Measure (Cambridge Ed.) |
| Number-word vocabulary (thirty+) | 968 | Martin Chuzzlewit |
| Chapter description paragraph merge | 968 | Martin Chuzzlewit |
| Chapter subtitle section merge | 968 | Martin Chuzzlewit |
| Front-matter nesting prevention | 1023, 588 | Bleak House, Master Humphrey's Clock |
| Non-keyword heading nesting (infer_from_rank) | 882 | Sketches by Boz |
| Backward start-index scan | 912, 588 | Mudfog Papers, Master Humphrey's Clock |
| Single-letter section indices | 912 | Mudfog Papers |
| Fallback heading-scan peer skip fix | — | General (commit 43b2f6c) |

## First Folio: all 35 plays

The First Folio (PG 2270) contains 35 plays encoded as `<p>` tags for both play titles and act/scene labels, with `<h5>` tags for special structural markers (INDVCTION, EPILOGVE, THE PROLOGVE). The parser now correctly produces:

| # | Play | Acts | Scenes | Special headings |
|---|------|------|--------|-----------------|
| 1 | The Tempest | 5 | 9 | — |
| 2 | The Two Gentlemen of Verona | 5 | 20 | — |
| 3 | The Merry Wives of Windsor | 5 | 23 | — |
| 4 | Measure for Measure | 5 | 17 | — |
| 5 | The Comedy of Errors | 5 | 11 | — |
| 6 | Much adoe about Nothing | 5 | 17 | — |
| 7 | Loves Labour's lost | 5 | 9 | — |
| 8 | A Midsummer Nights Dreame | 5 | 9 | — |
| 9 | The Merchant of Venice | 5 | 20 | — |
| 10 | As you Like it | 5 | 22 | — |
| 11 | The Taming of the Shrew | 5 | 14 | INDVCTION (2 scenes) |
| 12 | All's Well, that Ends Well | 5 | 23 | EPILOGVE |
| 13 | Twelfe-Night, Or what you will | 5 | 18 | — |
| 14 | The Winters Tale | 5 | 15 | — |
| 15 | The Life and Death of King John | 5 | 16 | — |
| 16 | The Life and death of Richard the Second | 5 | 19 | — |
| 17 | The First Part of Henry the Fourth | 5 | 19 | — |
| 18 | The Second Part of Henry the Fourth | 5 | 19 | INDVCTION, EPILOGVE |
| 19 | The Life of Henry the Fift | 5 | 23 | PROLOGVE (per-act) |
| 20 | The First Part of Henry the Sixt | 5 | 23 | — |
| 21 | The Second Part of Henry the Sixt | 5 | 18 | — |
| 22 | The Third Part of Henry the Sixt | 5 | 28 | — |
| 23 | The Tragedy of Richard the Third | 5 | 25 | — |
| 24 | The Famous History of the Life of King Henry the Eight | 5 | 16 | THE PROLOGVE, THE EPILOGVE |
| 25 | The Tragedie of Coriolanus | 5 | 29 | — |
| 26 | The Lamentable Tragedy of Titus Andronicus | 5 | 14 | — |
| 27 | The Tragedie of Romeo and Juliet | 5 | 24 | PROLOGVE |
| 28 | The Life of Tymon of Athens | 5 | 18 | — |
| 29 | The Tragedie of Julius Caesar | 5 | 18 | — |
| 30 | The Tragedie of Macbeth | 5 | 28 | — |
| 31 | The Tragedie of Hamlet | 5 | 20 | — |
| 32 | The Tragedie of King Lear | 5 | 26 | — |
| 33 | The Tragedie of Othello | 5 | 15 | — |
| 34 | Anthonie, and Cleopatra | 5 | 42 | — |
| 35 | The Tragedie of Cymbeline | 5 | 27 | — |

## Key bugs and fixes

### 1. V↔U regex breakage (`_common.py`)
`\bINDV?CTION\b` matched `INDVCTION` but **not** `INDUCTION` — `V?` makes V optional but doesn't include U as an alternative. Fixed to `\bIND[UV]?CTION\b`. Same fix applied to EPILOGUE and PROLOGUE patterns across three regexes.

### 2. First Folio multi-play collection detection (`_sections.py`)
The First Folio encodes 35 plays as `<p>` paragraphs with `<h5>` tags only for special markers. The old parser started at INDVCTION (row 297), skipping the first 17 plays entirely. Fixed via:
- `_fallback_start_index` extended to treat title-like paragraphs as structural in multi-play collections (multiple first-act keywords)
- H5 structural keywords (INDVCTION, EPILOGVE) demoted to rank 6 so they don't dominate play titles
- `_classify_level` demotes induction/epilogue from level 1 → 2 in collections
- `_nest_chapters_under_broad_containers` stops nesting at play title boundaries
- `_paragraph_heading_rows` emits play titles at rank 5 and act/scene at rank 6 (was all rank 7)

### 3. Play subtitle skipping (`_sections.py`)
`_find_play_title_paragraph` was returning subtitle lines like "Containing his Death: and the Coronation of King Henry the Fift" instead of the actual play title. Added `_PLAY_SUBTITLE_RE` to skip these patterns.

### 4. Single-play guard (`_sections.py`)
Standalone single-play editions (PG 1122 Hamlet) were getting an extra title heading from the paragraph scanner. Fixed by guarding title emission with `len(first_act_indices) > 1`.

### 5. Duplicate act heading merge guard (`_sections.py`)
Love's Labour's Lost (PG 1109) has two `Actus Quartus.` headings (a First Folio printing error). `_merge_adjacent_duplicate_sections` was merging them, dropping Act 5 content. Now counts paragraphs between anchors and preserves duplicates separated by ≥ 5 paragraphs.

### 6. Play heading paragraph regex (`_common.py`)
Failed on First Folio formats like `Actus primus, Scena prima.`. Fixed separator to `[,.:\s]+`, added SCAENA/SC\u0153NA variants, expanded ordinals to `[A-Za-z0-9]+` for Latin words.

### 7. Non-structural heading filter (`_headings.py`)
SONG, SENNET, ACTORS NAMES, and DRAMATIS PERSONAE headings broke act/scene nesting. Added to `_NON_STRUCTURAL_HEADING_RE`. THE END at rank ≥ 4 now filtered via `_DEEP_RANK_NON_STRUCTURAL_RE`.

### 8. TOC refinement for plays with omitted acts (`_sections.py`)
Measure for Measure (PG 23045) has a TOC listing scenes but omitting act-level headings. `_refine_toc_sections` now accepts broad containers (ACT, BOOK) with more prominent heading rank. `_refined_candidate_section` places them at TOC level for proper nesting.

### 9. Chapter description paragraph merging (`_sections.py`)
Martin Chuzzlewit has `<h2>CHAPTER I</h2><p>INTRODUCTORY, CONCERNING THE PEDIGREE…</p>`. New `_merge_chapter_description_paragraphs` merges ALL-CAPS descriptions (≤300 chars, ≥90% uppercase) into bare chapter headings and excludes them from body text.

### 10. Chapter subtitle section merging (`_sections.py`)
Same pattern but with `<h3>` subtitles: `_merge_chapter_subtitle_sections` merges non-keyword subtitles at rank+1 into their chapter heading, respecting TOC anchor IDs.

### 11. Front-matter nesting prevention (`_headings.py`, `_sections.py`)
"PREFACE TO THE FIRST VOLUME" matched broad keyword `volume`, becoming a level-1 container that nested all chapters. Fixed via `_is_front_matter_heading()` detection that blocks front-matter from both `_classify_level` broad promotion and `_nest_chapters_under_broad_containers`. Also blocked in `_is_valid_rank_parent` so PREFACE can't nest chapters via rank inference.

### 12. Non-keyword heading nesting via rank (`_sections.py`)
Sketches by Boz has `<h2>OUR PARISH</h2>` → `<h3>CHAPTER I</h3>` but OUR PARISH has no structural keyword. New `infer_from_rank` mode in `_respect_heading_rank_nesting` allows non-keyword headings to parent when rank gap is exactly 1, except front-matter headings.

### 13. Backward start-index scan (`_sections.py`)
Mudfog Papers has h2 story titles before h3 Section headings. Master Humphrey's Clock has h2 DEDICATION before h2 PREFACE. New backward scan in `_fallback_start_index` extends the start through contiguous peer-rank (±1) headings, excluding h1 titles.

### 14. Number-word vocabulary expansion (`_headings.py`)
"CHAPTER THIRTY-SIX" wasn't recognized because `_STRUCTURAL_INDEX_TOKEN_RE` only covered words through "twenty". Added thirty through ninety and corresponding ordinals.

### 15. Single-letter section indices (`_headings.py`)
"SECTION A" wasn't recognized because single-letter tokens weren't valid indices. Added special-case for `section` keyword only.

## Test plan

- [x] `test_first_folio_parses_all_plays_with_act_scene_hierarchy` — PG 2270: all 35 plays, INDVCTION/EPILOGVE nesting, Tempest hierarchy
- [x] 10 new Shakespeare network tests (PGs 1041, 1100, 1105, 1109, 1123, 1133, 1135, 1137, 1506, 23045)
- [x] 10 new unit tests in test_html_chunker.py (backward scan, number words, front-matter, description merge, section indices)
- [x] 3 modified battle test assertions (Macbeth count, Middlemarch finale, Beowulf nesting)
- [x] Full non-network test suite passes (374 tests)
- [x] Full network test suite passes (89 tests, 0 regressions)

https://claude.ai/code/session_0188w6FZPxJSsGYgCzNbtJLn
