### PR TITLE
Use code-block background for search button in both modes

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -48,7 +48,7 @@
   --md-accent-fg-color: var(--red);
   --md-accent-fg-color--transparent: var(--red-dim);
   --md-typeset-a-color: var(--red);
-  --md-code-bg-color: rgba(237,228,212,0.06);
+  --md-code-bg-color: rgba(237,228,212,0.12);
   --md-code-fg-color: var(--ink);
   --md-default-bg-color--light: rgba(var(--paper-rgb),0.7);
 }
@@ -104,7 +104,7 @@ body::before {
 }
 
 .md-search__button {
-  background-color: var(--md-default-bg-color--light, rgba(var(--paper-rgb),0.7)) !important;
+  background-color: var(--md-code-bg-color) !important;
 }
 
 .md-search__button::after {


### PR DESCRIPTION
Match the search button background to --md-code-bg-color so it has visible contrast in dark mode. Bump dark mode code-bg opacity from 0.06 to 0.12 for better visibility of both code blocks and search.